### PR TITLE
Provide required aqt.AnkiQt to TaskManager

### DIFF
--- a/pytest_anki/__init__.py
+++ b/pytest_anki/__init__.py
@@ -94,7 +94,7 @@ def _patched_ankiqt_init(
     self.state = "startup"
     self.opts = opts
     self.col: Optional[_Collection] = None  # type: ignore
-    self.taskman = TaskManager()
+    self.taskman = TaskManager(self)
     self.media_syncer = MediaSyncer(self)
     aqt.mw = self
     self.app = app


### PR DESCRIPTION
Tests for this plugin were failing with a `TypeError` due to a missing argument for `TaskManager`.  This PR provides the missing argument.