### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Install anki
         working-directory: anki_root
         run: |
+          python -m pip install --upgrade pip
           pip install aqt
           pip install .
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,6 @@ name: tests
 
 on:
   push:
-    branches: [ "**" ]
     paths-ignore:
       - "README.md"
       - "docs/**"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
           node-version: 12
 
       - name: Set up protoc build dependency for anki
-        uses: Arduino/actions/setup-protoc@master
+        uses: arduino/setup-protoc@v1
 
       # venv is automatically set up by this step
       # FIXME: currently bypassing pip installation due to a pip bug

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,18 +14,16 @@ on:
 jobs:
   test:
     runs-on: macos-latest
-
     steps:
+      - name: Checkout pytest-anki
+        uses: actions/checkout@v2
+
       - name: Setup Python
         uses: actions/setup-python@v2.2.1
         with:
           python-version: 3.8
 
-      - name: Checkout pytest-anki
-        uses: actions/checkout@v2
-
       - name: Install anki
-        working-directory: anki_root
         run: |
           python -m pip install --upgrade pip
           pip install aqt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@ name: tests
 
 on:
   push:
+    branches: [ "**" ]
     paths-ignore:
       - "README.md"
       - "docs/**"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,61 +13,23 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
-      - name: Set up python
-        uses: actions/setup-python@v1
+      - name: Setup Python
+        uses: actions/setup-python@v2.2.1
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Checkout pytest-anki
         uses: actions/checkout@v2
 
-      - name: Checkout anki
-        uses: actions/checkout@v2
-        with:
-          repository: dae/anki
-          path: anki_root
-
-      - name: Checkout latest Anki tag
+      - name: Install anki
         working-directory: anki_root
         run: |
-          git fetch --tags
-          git checkout $(git tag --sort=version:refname | tail -1)
-
-      - name: Set up python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Set up node build dependency for anki
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12
-
-      - name: Set up protoc build dependency for anki
-        uses: arduino/setup-protoc@v1
-
-      # venv is automatically set up by this step
-      # FIXME: currently bypassing pip installation due to a pip bug
-      # https://github.com/pypa/pip/issues/7217
-      - name: Install anki dependencies and build anki
-        working-directory: anki_root
-        run: |
-          sudo apt-get install portaudio19-dev gettext rename
-          sed -i 's/pip install --upgrade pip setuptools/true/g' Makefile
-          pip install --upgrade pip==19.3.1 setuptools==45.0.0
-          make build BUILDFLAGS=""
-          make develop
-
-      - name: Install pytest-anki and its dependencies
-        run: |
-          . ./anki_root/pyenv/bin/activate
-          sudo apt-get install xvfb libxkbcommon-x11-0
+          pip install aqt
           pip install .
 
       - name: Run tests
         run: |
-          . ./anki_root/pyenv/bin/activate
           ./tools/run_tests.sh


### PR DESCRIPTION
I was unable to get this workflow running on GitHubs `ubuntu-latest` VM.  This may be an unacceptable compromise, but I was able to get pytest-anki working in CI (🎉 ) by using the `macos-latest` VM.

I also opted for pip installing aqt rather than building Anki from source.  I've been unsuccessful with the new build system and am not interested in spending any more time tinkering with it.

Take this or leave it, just wanted to share my work in case it's useful.  Cheers! 😄 

EDIT:  BTW, the failing check is expected.  I just pip installed aqt w/o pinning it a specific version, which means pip grabs the latest.  The check is failing due to breaking Anki changes.  This is actually great because it means this can serve as a way to learn about breaking changes automatically.