### PR TITLE
Configure test matrix for different Anki versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 jobs:
-  test:
+  pytest:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
@@ -27,6 +27,10 @@ jobs:
               python: 3.8.0
               pyqt: 5.14.2
               pyqtwebengine: 5.14.0
+            - anki: 2.1.28
+              python: 3.8.0
+              pyqt: 5.15.0
+              pyqtwebengine: 5.15.0
 
     steps:
       # Qt5 requires a number of X11-related dependencies to be installed system-wide
@@ -58,7 +62,7 @@ jobs:
       - name: Set up Anki ${{ matrix.anki }}
         run: |
           pip install --upgrade setuptools pip
-          pip install PyQt5==${{ matrix.pyqt }} PyQtWebEngine==${{ matrix.pyqtwebengine }} anki==${{ matrix.anki }} aqt==${{ matrix.anki }}
+          pip install --upgrade PyQt5==${{ matrix.pyqt }} PyQtWebEngine==${{ matrix.pyqtwebengine }} anki==${{ matrix.anki }} aqt==${{ matrix.anki }}
 
       - name: Run tests for Anki ${{ matrix.anki }}
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         include:
-            - anki: 2.1.46
+            - anki: 2.1.47
               python: 3.8.6
               pyqt: 5.15.1
               pyqtwebengine: 5.15.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,10 +35,6 @@ jobs:
               python: 3.8.0
               pyqt: 5.13.1
               pyqtwebengine: 5.13.1
-            - anki: 2.1.23
-              python: 3.8.0
-              pyqt: 5.13.1
-              pyqtwebengine: 5.13.1
 
     steps:
       # Qt5 requires a number of X11-related dependencies to be installed system-wide

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,22 @@ on:
 jobs:
   test:
     runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        include:
+            - anki: 2.1.46
+              python: 3.8.6
+              pyqt: 5.15.1
+              pyqtwebengine: 5.15.1
+            - anki: 2.1.44
+              python: 3.8.6
+              pyqt: 5.14.2
+              pyqtwebengine: 5.14.0
+            - anki: 2.1.35
+              python: 3.8.0
+              pyqt: 5.14.2
+              pyqtwebengine: 5.14.0
+
     steps:
       # Qt5 requires a number of X11-related dependencies to be installed system-wide
       # Rather than installing each individually, we install libqt5 system-wide which
@@ -24,10 +40,10 @@ jobs:
       - name: Checkout pytest-anki
         uses: actions/checkout@v2
 
-      - name: Setup Python
+      - name: Setup Python ${{ matrix.python }}
         uses: actions/setup-python@v2.2.1
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python }}
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
@@ -39,6 +55,11 @@ jobs:
         run: |
           make install
 
-      - name: Run tests
+      - name: Set up Anki ${{ matrix.anki }}
+        run: |
+          pip install --upgrade setuptools pip
+          pip install PyQt5==${{ matrix.pyqt }} PyQtWebEngine==${{ matrix.pyqtwebengine }} anki==${{ matrix.anki }} aqt==${{ matrix.anki }}
+
+      - name: Run tests for Anki ${{ matrix.anki }}
         run: |
           make test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,10 @@ jobs:
           version: 1.1.8
           virtualenvs-create: false
 
+      - name: Set up pytest-anki
+        run: |
+          make install
+
       - name: Run tests
         run: |
-          ./tools/run_tests.sh
+          make test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,10 @@ jobs:
               python: 3.8.0
               pyqt: 5.13.1
               pyqtwebengine: 5.13.1
+            - anki: 2.1.23
+              python: 3.8.0
+              pyqt: 5.13.1
+              pyqtwebengine: 5.13.1
 
     steps:
       # Qt5 requires a number of X11-related dependencies to be installed system-wide

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,10 @@ jobs:
               python: 3.8.0
               pyqt: 5.15.0
               pyqtwebengine: 5.15.0
+            - anki: 2.1.26
+              python: 3.8.0
+              pyqt: 5.13.1
+              pyqtwebengine: 5.13.1
 
     steps:
       # Qt5 requires a number of X11-related dependencies to be installed system-wide

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,11 +16,11 @@ jobs:
       matrix:
         include:
             - anki: 2.1.47
-              python: 3.8.6
+              python: 3.8.1
               pyqt: 5.15.1
               pyqtwebengine: 5.15.1
             - anki: 2.1.44
-              python: 3.8.6
+              python: 3.8.1
               pyqt: 5.14.2
               pyqtwebengine: 5.14.0
             - anki: 2.1.35

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+SHELL = /bin/bash
+
+TEST_FLAGS ?= -n4
+
+install:
+	poetry install
+
+test:
+	python -m pytest $(TEST_FLAGS) tests/
+
+build:
+	poetry build
+
+# Show help message
+help:
+	@echo "$$(tput bold)Available targets:$$(tput sgr0)";echo;sed -ne"/^# /{h;s/.*//;:d" -e"H;n;s/^# //;td" -e"s/:.*//;G;s/\\n# /---/;s/\\n/ /g;p;}" ${MAKEFILE_LIST}|LC_ALL='C' sort -f|awk -F --- -v n=$$(tput cols) -v i=19 -v a="$$(tput setaf 6)" -v z="$$(tput sgr0)" '{printf"%s%*s%s ",a,-i,$$1,z;m=split($$2,w," ");l=n-i;for(j=1;j<=m;j++){l-=length(w[j])+1;if(l<= 0){l=n-i-length(w[j])-1;printf"\n%*s ",-i," ";}printf"%s ",w[j];}printf"\n";}'
+
+.DEFAULT_GOAL: help
+.PHONY: install test build

--- a/pytest_anki/_decks.py
+++ b/pytest_anki/_decks.py
@@ -52,7 +52,8 @@ def deck_installed(
 
     deck_id = next(iter(new_ids - old_ids))
 
-    yield deck_id
+    # deck_id is str on <= 2.1.26
+    yield int(deck_id)
 
     if keep:
         return

--- a/pytest_anki/_patch.py
+++ b/pytest_anki/_patch.py
@@ -93,21 +93,32 @@ def custom_init_factory(
         main_window.state = "startup"
         main_window.opts = opts
         main_window.col: Optional["Collection"] = None  # type: ignore
-        main_window.taskman = TaskManager(main_window)
+
+        try:  # 2.1.28+
+            main_window.taskman = TaskManager(main_window)
+        except TypeError:
+            main_window.taskman = TaskManager()  # type: ignore
+
         main_window.media_syncer = MediaSyncer(main_window)
+        
         try:  # 2.1.45+
             from aqt.flags import FlagManager
 
             main_window.flags = FlagManager(main_window)
         except (ImportError, ModuleNotFoundError):
             pass
+        
         aqt.mw = main_window
         main_window.app = app
         main_window.pm = profileManager
         main_window.safeMode = False  # disable safe mode, of no use to us
         main_window.setupUI()
         _setup_addons(main_window)
-        main_window.finish_ui_setup()
+        
+        try:  # 2.1.28+
+            main_window.finish_ui_setup()
+        except AttributeError:
+            pass
 
     return custom_init
 

--- a/tools/run_tests.sh
+++ b/tools/run_tests.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-poetry install
-pytest -n4 tests/


### PR DESCRIPTION
Add a test matrix for Anki 2.1.26 - 2.1.46.

We'll have to think about whether it makes sense to check against the latest version within this workflow. Generally, having PRs fail if they are incompatible with an Anki version that's not officially supported by the project might introduce too much noise.

Add-ons can of course implement their own test matrix and include bleeding edge versions.

Ideally we'd have a separate workflow that gets triggered any time Anki pushes a new tag and then notifies everyone watching the repository of a breakage, but that will likely require setting up an external service.

----

_Note: This patch was written under commission for AMBOSS MD Inc. Its rights of use and exploitation lie with AMBOSS MD Inc. It is submitted as a contribution to pytest-anki under pytest-anki's license terms (see LICENSE file)._