### PR TITLE
Add parametrization for add-on configuration

### DIFF
--- a/pytest_anki/__init__.py
+++ b/pytest_anki/__init__.py
@@ -36,7 +36,6 @@ A simple pytest plugin for testing Anki add-ons
 from ._fixtures import anki_session  # noqa: F401
 from ._launch import anki_running  # noqa: F401
 from ._session import AnkiSession  # noqa: F401
-from ._types import UnpackedAddon  # noqa: F401
 
 __version__ = "1.0.0-dev.1"
 __author__ = "Aristotelis P. (Glutanimate), Michal Krassowski"

--- a/pytest_anki/__init__.py
+++ b/pytest_anki/__init__.py
@@ -39,7 +39,7 @@ from ._session import AnkiSession  # noqa: F401
 
 # Argument types:
 
-from ._anki import PresetAnkiState  # noqa: F401
+from ._anki import PresetAnkiState, AnkiStorageObject  # noqa: F401
 
 __version__ = "1.0.0-dev.1"
 __author__ = "Aristotelis P. (Glutanimate), Michal Krassowski"

--- a/pytest_anki/__init__.py
+++ b/pytest_anki/__init__.py
@@ -33,13 +33,10 @@
 A simple pytest plugin for testing Anki add-ons
 """
 
-from ._anki import PresetAnkiState  # noqa: F401
+from ._anki import AnkiStateUpdate  # noqa: F401
 from ._fixtures import anki_session  # noqa: F401
 from ._launch import anki_running  # noqa: F401
 from ._session import AnkiSession  # noqa: F401
-
-# Argument types:
-
 
 __version__ = "1.0.0-dev.1"
 __author__ = "Aristotelis P. (Glutanimate), Michal Krassowski"

--- a/pytest_anki/__init__.py
+++ b/pytest_anki/__init__.py
@@ -33,13 +33,13 @@
 A simple pytest plugin for testing Anki add-ons
 """
 
+from ._anki import PresetAnkiState  # noqa: F401
 from ._fixtures import anki_session  # noqa: F401
 from ._launch import anki_running  # noqa: F401
 from ._session import AnkiSession  # noqa: F401
 
 # Argument types:
 
-from ._anki import PresetAnkiState, AnkiStorageObject  # noqa: F401
 
 __version__ = "1.0.0-dev.1"
 __author__ = "Aristotelis P. (Glutanimate), Michal Krassowski"

--- a/pytest_anki/__init__.py
+++ b/pytest_anki/__init__.py
@@ -37,6 +37,10 @@ from ._fixtures import anki_session  # noqa: F401
 from ._launch import anki_running  # noqa: F401
 from ._session import AnkiSession  # noqa: F401
 
+# Argument types:
+
+from ._anki import PresetAnkiState  # noqa: F401
+
 __version__ = "1.0.0-dev.1"
 __author__ = "Aristotelis P. (Glutanimate), Michal Krassowski"
 __title__ = "pytest-anki"

--- a/pytest_anki/_addons.py
+++ b/pytest_anki/_addons.py
@@ -30,12 +30,7 @@
 
 import shutil
 from pathlib import Path
-from typing import (
-    Any,
-    Dict,
-    NamedTuple,
-    Optional,
-)
+from typing import Any, Dict, NamedTuple, Optional
 
 from aqt.addons import AddonManager
 

--- a/pytest_anki/_anki.py
+++ b/pytest_anki/_anki.py
@@ -43,6 +43,17 @@ if TYPE_CHECKING:
 
 @dataclass
 class PresetAnkiState:
+    
+    """
+    Specifies Anki object state to be pre-configured for the test session.
+    
+    This includes the three main configuration storages used by add-ons:
+    
+    - mw.col.conf (colconf_storage), available at profile load time
+    - mw.pm.profile (profile_storage), available at profile load time
+    - mw.pm.meta (meta_storage), available at add-on load time
+    """
+    
     colconf_storage: Optional[Dict[str, Any]] = None
     profile_storage: Optional[Dict[str, Any]] = None
     meta_storage: Optional[Dict[str, Any]] = None

--- a/pytest_anki/_anki.py
+++ b/pytest_anki/_anki.py
@@ -28,20 +28,28 @@
 #
 # Any modifications to this file must keep this entire header intact.
 
+from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from ._errors import AnkiSessionError
 from ._util import get_nested_attribute
 
 if TYPE_CHECKING:
+    from anki.collection import Collection
     from anki.config import ConfigManager
     from aqt.main import AnkiQt
-    from anki.collection import Collection
+
+
+@dataclass
+class PresetAnkiState:
+    colconf_storage: Optional[Dict[str, Any]] = None
+    profile_storage: Optional[Dict[str, Any]] = None
+    meta_storage: Optional[Dict[str, Any]] = None
 
 
 class AnkiStorageObject(Enum):
-    synced_storage = "col.conf"
+    colconf_storage = "col.conf"
     profile_storage = "pm.profile"
     meta_storage = "pm.meta"
 
@@ -52,6 +60,42 @@ def get_collection(main_window: "AnkiQt") -> "Collection":
             "Collection has not been loaded, yet. Please use load_profile()."
         )
     return collection
+
+
+def apply_anki_profile_state(main_window: "AnkiQt", preset_anki_state: PresetAnkiState):
+    apply_anki_state(
+        main_window=main_window,
+        storage_object=AnkiStorageObject.profile_storage,
+        preset_anki_state=preset_anki_state,
+    )
+
+
+def apply_anki_meta_state(main_window: "AnkiQt", preset_anki_state: PresetAnkiState):
+    apply_anki_state(
+        main_window=main_window,
+        storage_object=AnkiStorageObject.meta_storage,
+        preset_anki_state=preset_anki_state,
+    )
+
+
+def apply_anki_colconf_state(main_window: "AnkiQt", preset_anki_state: PresetAnkiState):
+    apply_anki_state(
+        main_window=main_window,
+        storage_object=AnkiStorageObject.colconf_storage,
+        preset_anki_state=preset_anki_state,
+    )
+
+
+def apply_anki_state(
+    main_window: "AnkiQt",
+    storage_object: AnkiStorageObject,
+    preset_anki_state: PresetAnkiState,
+):
+    data: Optional[Dict[str, Any]] = getattr(preset_anki_state, storage_object.name)
+    if data:
+        set_anki_object_data(
+            main_window=main_window, storage_object=storage_object, data=data
+        )
 
 
 def set_anki_object_data(

--- a/pytest_anki/_anki.py
+++ b/pytest_anki/_anki.py
@@ -121,7 +121,7 @@ def set_anki_object_data(
         main_window=main_window, storage_object=storage_object
     )
 
-    if storage_object == AnkiStorageObject.synced_storage:
+    if storage_object == AnkiStorageObject.colconf_storage:
         # mw.col.conf dict API is deprecated in favor of ConfigManager API
         collection = get_collection(main_window=main_window)
         for key, value in data.items():

--- a/pytest_anki/_anki.py
+++ b/pytest_anki/_anki.py
@@ -1,0 +1,91 @@
+# pytest-anki
+#
+# Copyright (C)  2019-2021 Aristotelis P. <https://glutanimate.com/>
+#                and contributors (see CONTRIBUTORS file)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version, with the additions
+# listed at the end of the license file that accompanied this program.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# NOTE: This program is subject to certain additional terms pursuant to
+# Section 7 of the GNU Affero General Public License.  You should have
+# received a copy of these additional terms immediately following the
+# terms and conditions of the GNU Affero General Public License that
+# accompanied this program.
+#
+# If not, please request a copy through one of the means of contact
+# listed here: <https://glutanimate.com/contact/>.
+#
+# Any modifications to this file must keep this entire header intact.
+
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Dict, Union
+
+from ._errors import AnkiSessionError
+from ._util import get_nested_attribute
+
+if TYPE_CHECKING:
+    from anki.config import ConfigManager
+    from aqt.main import AnkiQt
+    from anki.collection import Collection
+
+
+class AnkiStorageObject(Enum):
+    synced_storage = "col.conf"
+    profile_storage = "pm.profile"
+    meta_storage = "pm.meta"
+
+
+def get_collection(main_window: "AnkiQt") -> "Collection":
+    if (collection := main_window.col) is None:
+        raise AnkiSessionError(
+            "Collection has not been loaded, yet. Please use load_profile()."
+        )
+    return collection
+
+
+def set_anki_object_data(
+    main_window: "AnkiQt", storage_object: AnkiStorageObject, data: dict
+) -> Union[Dict[str, Any], "ConfigManager"]:
+    """Update the data of a specified Anki storage object
+
+    This may be used to simulate specific Anki and/or add-on states
+    during testing."""
+
+    anki_object = get_anki_object(
+        main_window=main_window, storage_object=storage_object
+    )
+
+    if storage_object == AnkiStorageObject.synced_storage:
+        # mw.col.conf dict API is deprecated in favor of ConfigManager API
+        collection = get_collection(main_window=main_window)
+        for key, value in data.items():
+            collection.set_config(key, value)
+    else:
+        anki_object.update(data)  # type: ignore
+
+    return anki_object
+
+
+def get_anki_object(
+    main_window: "AnkiQt", storage_object: AnkiStorageObject
+) -> Union[Dict[str, Any], "ConfigManager"]:
+    """Get Anki object for specified AnkiStorageObject type"""
+    attribute_path = storage_object.value
+    try:
+        return get_nested_attribute(obj=main_window, attr=attribute_path)
+    except Exception as e:
+        raise AnkiSessionError(
+            f"Anki storage object {storage_object.name} could not be accessed:"
+            f" {str(e)}"
+        )

--- a/pytest_anki/_anki.py
+++ b/pytest_anki/_anki.py
@@ -43,17 +43,17 @@ if TYPE_CHECKING:
 
 @dataclass
 class PresetAnkiState:
-    
+
     """
     Specifies Anki object state to be pre-configured for the test session.
-    
+
     This includes the three main configuration storages used by add-ons:
-    
+
     - mw.col.conf (colconf_storage), available at profile load time
     - mw.pm.profile (profile_storage), available at profile load time
     - mw.pm.meta (meta_storage), available at add-on load time
     """
-    
+
     colconf_storage: Optional[Dict[str, Any]] = None
     profile_storage: Optional[Dict[str, Any]] = None
     meta_storage: Optional[Dict[str, Any]] = None
@@ -74,7 +74,7 @@ def get_collection(main_window: "AnkiQt") -> "Collection":
 
 
 def apply_anki_profile_state(main_window: "AnkiQt", preset_anki_state: PresetAnkiState):
-    apply_anki_state(
+    _apply_single_anki_state(
         main_window=main_window,
         storage_object=AnkiStorageObject.profile_storage,
         preset_anki_state=preset_anki_state,
@@ -82,7 +82,7 @@ def apply_anki_profile_state(main_window: "AnkiQt", preset_anki_state: PresetAnk
 
 
 def apply_anki_meta_state(main_window: "AnkiQt", preset_anki_state: PresetAnkiState):
-    apply_anki_state(
+    _apply_single_anki_state(
         main_window=main_window,
         storage_object=AnkiStorageObject.meta_storage,
         preset_anki_state=preset_anki_state,
@@ -90,14 +90,14 @@ def apply_anki_meta_state(main_window: "AnkiQt", preset_anki_state: PresetAnkiSt
 
 
 def apply_anki_colconf_state(main_window: "AnkiQt", preset_anki_state: PresetAnkiState):
-    apply_anki_state(
+    _apply_single_anki_state(
         main_window=main_window,
         storage_object=AnkiStorageObject.colconf_storage,
         preset_anki_state=preset_anki_state,
     )
 
 
-def apply_anki_state(
+def _apply_single_anki_state(
     main_window: "AnkiQt",
     storage_object: AnkiStorageObject,
     preset_anki_state: PresetAnkiState,
@@ -106,6 +106,23 @@ def apply_anki_state(
     if data:
         set_anki_object_data(
             main_window=main_window, storage_object=storage_object, data=data
+        )
+
+
+def apply_anki_state(main_window: "AnkiQt", preset_anki_state: PresetAnkiState):
+    if preset_anki_state.meta_storage:
+        apply_anki_meta_state(
+            main_window=main_window, preset_anki_state=preset_anki_state
+        )
+
+    if preset_anki_state.profile_storage:
+        apply_anki_profile_state(
+            main_window=main_window, preset_anki_state=preset_anki_state
+        )
+
+    if preset_anki_state.colconf_storage:
+        apply_anki_colconf_state(
+            main_window=main_window, preset_anki_state=preset_anki_state
         )
 
 

--- a/pytest_anki/_anki.py
+++ b/pytest_anki/_anki.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class PresetAnkiState:
+class AnkiStateUpdate:
 
     """
     Specifies Anki object state to be pre-configured for the test session.
@@ -73,56 +73,56 @@ def get_collection(main_window: "AnkiQt") -> "Collection":
     return collection
 
 
-def apply_anki_profile_state(main_window: "AnkiQt", preset_anki_state: PresetAnkiState):
-    _apply_single_anki_state(
+def update_anki_profile_state(main_window: "AnkiQt", anki_state_update: AnkiStateUpdate):
+    _update_single_anki_state(
         main_window=main_window,
         storage_object=AnkiStorageObject.profile_storage,
-        preset_anki_state=preset_anki_state,
+        anki_state_update=anki_state_update,
     )
 
 
-def apply_anki_meta_state(main_window: "AnkiQt", preset_anki_state: PresetAnkiState):
-    _apply_single_anki_state(
+def update_anki_meta_state(main_window: "AnkiQt", anki_state_update: AnkiStateUpdate):
+    _update_single_anki_state(
         main_window=main_window,
         storage_object=AnkiStorageObject.meta_storage,
-        preset_anki_state=preset_anki_state,
+        anki_state_update=anki_state_update,
     )
 
 
-def apply_anki_colconf_state(main_window: "AnkiQt", preset_anki_state: PresetAnkiState):
-    _apply_single_anki_state(
+def update_anki_colconf_state(main_window: "AnkiQt", anki_state_update: AnkiStateUpdate):
+    _update_single_anki_state(
         main_window=main_window,
         storage_object=AnkiStorageObject.colconf_storage,
-        preset_anki_state=preset_anki_state,
+        anki_state_update=anki_state_update,
     )
 
 
-def _apply_single_anki_state(
+def _update_single_anki_state(
     main_window: "AnkiQt",
     storage_object: AnkiStorageObject,
-    preset_anki_state: PresetAnkiState,
+    anki_state_update: AnkiStateUpdate,
 ):
-    data: Optional[Dict[str, Any]] = getattr(preset_anki_state, storage_object.name)
+    data: Optional[Dict[str, Any]] = getattr(anki_state_update, storage_object.name)
     if data:
         set_anki_object_data(
             main_window=main_window, storage_object=storage_object, data=data
         )
 
 
-def apply_anki_state(main_window: "AnkiQt", preset_anki_state: PresetAnkiState):
-    if preset_anki_state.meta_storage:
-        apply_anki_meta_state(
-            main_window=main_window, preset_anki_state=preset_anki_state
+def update_anki_state(main_window: "AnkiQt", anki_state_update: AnkiStateUpdate):
+    if anki_state_update.meta_storage:
+        update_anki_meta_state(
+            main_window=main_window, anki_state_update=anki_state_update
         )
 
-    if preset_anki_state.profile_storage:
-        apply_anki_profile_state(
-            main_window=main_window, preset_anki_state=preset_anki_state
+    if anki_state_update.profile_storage:
+        update_anki_profile_state(
+            main_window=main_window, anki_state_update=anki_state_update
         )
 
-    if preset_anki_state.colconf_storage:
-        apply_anki_colconf_state(
-            main_window=main_window, preset_anki_state=preset_anki_state
+    if anki_state_update.colconf_storage:
+        update_anki_colconf_state(
+            main_window=main_window, anki_state_update=anki_state_update
         )
 
 

--- a/pytest_anki/_errors.py
+++ b/pytest_anki/_errors.py
@@ -32,5 +32,6 @@
 class AnkiLaunchException(Exception):
     pass
 
+
 class AnkiSessionError(Exception):
     pass

--- a/pytest_anki/_fixtures.py
+++ b/pytest_anki/_fixtures.py
@@ -43,23 +43,25 @@ from ._session import AnkiSession
 def anki_session(request: "FixtureRequest") -> Iterator[AnkiSession]:
     """Fixture that instantiates Anki, yielding an AnkiSession object
 
-    Additional arguments may be passed to the fixture by using indirect parametrization.
-    E.g., to specify a custom profile name you would do:
+    All keyword arguments below may be passed to the fixture by using indirect
+    parametrization.
+    
+    E.g., to specify a custom profile name you would decorate your test method with:
 
     > @pytest.mark.parametrize("anki_session", [dict(profile_name="foo")],
                                indirect=True)
 
-    Full list of supported keyword arguments as parameters:
+    Keyword Arguments:
         base_path {str} -- Path to write Anki base folder to
-                           (default: {tempfile.gettempdir()})
+            (default: system-wide temporary directory)
         base_name {str} -- Base folder name (default: {"anki_base"})
         profile_name {str} -- User profile name (default: {"__Temporary Test User__"})
         keep_profile {bool} -- Whether to preserve profile at context exit
-                               (default: {False})
+            (default: {False})
         load_profile {bool} -- Whether to preload Anki user profile (with collection)
-                               (default: {False})
-        force_early_profile_load {bool} -- Whether to load Anki profile
-            (without collection) at app init time. Replicates the behavior when
+            (default: {False})
+        force_early_profile_load {bool} -- Whether to load Anki profile at app
+            initialization time (without collection). Replicates the behavior when
             passing profile as a CLI argument (default: {False})
         lang {str} -- Language to use for the user profile (default: {"en_US"})
         packed_addons {Optional[List[PathLike]]}: List of paths to .ankiaddon-packaged

--- a/pytest_anki/_fixtures.py
+++ b/pytest_anki/_fixtures.py
@@ -40,8 +40,8 @@ from ._session import AnkiSession
 def anki_session(request) -> Iterator[AnkiSession]:
     """Fixture that instantiates Anki, yielding an AnkiSession object
 
-    Additional arguments may be passed to the fixture by using indirect parametrization,
-    e.g.:
+    Additional arguments may be passed to the fixture by using indirect parametrization.
+    E.g., to specify a custom profile name you would do:
 
     > @pytest.mark.parametrize("anki_session", [dict(profile_name="foo")],
                                indirect=True)
@@ -61,10 +61,11 @@ def anki_session(request) -> Iterator[AnkiSession]:
         lang {str} -- Language to use for the user profile (default: {"en_US"})
         packed_addons {Optional[List[PathLike]]}: List of paths to .ankiaddon-packaged
             add-ons that should be installed ahead of starting Anki
-        unpacked_addons {Optional[List[UnpackedAddons]]}: List of unpackaged add-ons
-            that should be installed ahead of starting Anki, described via the
-            UnpackagedApacked_addons Yields:
-        Iterator[AnkiSession] unpacked_addonsfixture
+        unpacked_addons {Optional[List[Tuple[PathLike, str]]]}:
+            List of unpacked add-ons that should be installed ahead of starting Anki.
+            Add-ons need to be specified as tuple of the path to the add-on directory
+            and the package name under which they should be installed.
+    
     # https://docs.pytest.org/en/latest/reference.html#request
     """
 

--- a/pytest_anki/_fixtures.py
+++ b/pytest_anki/_fixtures.py
@@ -45,7 +45,7 @@ def anki_session(request: "FixtureRequest") -> Iterator[AnkiSession]:
 
     All keyword arguments below may be passed to the fixture by using indirect
     parametrization.
-    
+
     E.g., to specify a custom profile name you would decorate your test method with:
 
     > @pytest.mark.parametrize("anki_session", [dict(profile_name="foo")],
@@ -66,10 +66,16 @@ def anki_session(request: "FixtureRequest") -> Iterator[AnkiSession]:
         lang {str} -- Language to use for the user profile (default: {"en_US"})
         packed_addons {Optional[List[PathLike]]}: List of paths to .ankiaddon-packaged
             add-ons that should be installed ahead of starting Anki
-        unpacked_addons {Optional[List[Tuple[PathLike, str]]]}:
+        unpacked_addons {Optional[List[Tuple[str, PathLike]]]}:
             List of unpacked add-ons that should be installed ahead of starting Anki.
-            Add-ons need to be specified as tuple of the path to the add-on directory
-            and the package name under which they should be installed.
+            Add-ons need to be specified as tuple of the add-on package name under which
+            to install the add-on, and the path to the source folder (the package
+            folder containing the add-on __init__.py)
+        addon_configs {Optional[List[Tuple[str, Dict[str, Any]]]]}:
+            List of add-on package names and config values to set the user configuration
+            for the specified add-on to. Useful for simulating specific config set-ups.
+            Each list member needs to be specified as a tuple of add-on package name
+            and dictionary of user configuration values to set.
 
     # https://docs.pytest.org/en/latest/reference.html#request
     """

--- a/pytest_anki/_fixtures.py
+++ b/pytest_anki/_fixtures.py
@@ -86,7 +86,7 @@ def anki_session(request: "FixtureRequest") -> Iterator[AnkiSession]:
             Each list member needs to be specified as a tuple of add-on package name
             and dictionary of user configuration values to set.
 
-        preset_anki_state Optional[PresetAnkiState]:
+        preset_anki_state {Optional[pytest_anki.AnkiStateUpdate]}:
             Allows pre-configuring Anki object state, as described by a PresetAnkiState
             dataclass. This includes the three main configuration storages used by
             add-ons, mw.col.conf (colconf_strage), mw.pm.profile (profile_storage),

--- a/pytest_anki/_fixtures.py
+++ b/pytest_anki/_fixtures.py
@@ -28,16 +28,19 @@
 #
 # Any modifications to this file must keep this entire header intact.
 
-from typing import Iterator
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional
 
 import pytest
+
+if TYPE_CHECKING:
+    from pytest import FixtureRequest
 
 from ._launch import anki_running
 from ._session import AnkiSession
 
 
 @pytest.fixture
-def anki_session(request) -> Iterator[AnkiSession]:
+def anki_session(request: "FixtureRequest") -> Iterator[AnkiSession]:
     """Fixture that instantiates Anki, yielding an AnkiSession object
 
     Additional arguments may be passed to the fixture by using indirect parametrization.
@@ -65,11 +68,13 @@ def anki_session(request) -> Iterator[AnkiSession]:
             List of unpacked add-ons that should be installed ahead of starting Anki.
             Add-ons need to be specified as tuple of the path to the add-on directory
             and the package name under which they should be installed.
-    
+
     # https://docs.pytest.org/en/latest/reference.html#request
     """
 
-    param = getattr(request, "param", None)
+    indirect_parameters: Optional[Dict[str, Any]] = getattr(request, "param", None)
 
-    with anki_running() if not param else anki_running(**param) as session:
+    with anki_running() if not indirect_parameters else anki_running(
+        **indirect_parameters
+    ) as session:
         yield session

--- a/pytest_anki/_fixtures.py
+++ b/pytest_anki/_fixtures.py
@@ -54,52 +54,52 @@ def anki_session(request: "FixtureRequest") -> Iterator[AnkiSession]:
     Keyword Arguments:
         base_path {str} -- Path to write Anki base folder to
             (default: system-wide temporary directory)
-        
+
         base_name {str} -- Base folder name (default: {"anki_base"})
-        
+
         profile_name {str} -- User profile name (default: {"__Temporary Test User__"})
-        
+
         keep_profile {bool} -- Whether to preserve profile at context exit
             (default: {False})
-        
+
         load_profile {bool} -- Whether to preload Anki user profile (with collection)
             (default: {False})
-        
+
         force_early_profile_load {bool} -- Whether to load Anki profile at app
             initialization time (without collection). Replicates the behavior when
             passing profile as a CLI argument (default: {False})
-        
+
         lang {str} -- Language to use for the user profile (default: {"en_US"})
-        
+
         packed_addons {Optional[List[PathLike]]}: List of paths to .ankiaddon-packaged
             add-ons that should be installed ahead of starting Anki
-        
+
         unpacked_addons {Optional[List[Tuple[str, PathLike]]]}:
             List of unpacked add-ons that should be installed ahead of starting Anki.
             Add-ons need to be specified as tuple of the add-on package name under which
             to install the add-on, and the path to the source folder (the package
             folder containing the add-on __init__.py)
-        
+
         addon_configs {Optional[List[Tuple[str, Dict[str, Any]]]]}:
             List of add-on package names and config values to set the user configuration
             for the specified add-on to. Useful for simulating specific config set-ups.
             Each list member needs to be specified as a tuple of add-on package name
             and dictionary of user configuration values to set.
-        
+
         preset_anki_state Optional[PresetAnkiState]:
             Allows pre-configuring Anki object state, as described by a PresetAnkiState
             dataclass. This includes the three main configuration storages used by
             add-ons, mw.col.conf (colconf_strage), mw.pm.profile (profile_storage),
             and mw.pm.meta (meta_storage).
-            
+
             The provided data is applied on top of the existing data in each case
             (i.e. in the same way as dict.update(new_data) would).
-            
+
             State specified in this manner is guaranteed to be pre-configured ahead of
             add-on load time (in the case of meta_storage), or ahead of
             gui_hooks.profile_did_open fire time (in the case of colconf_storage and
             profile_storage).
-            
+
             Please note that, in the case of colconf_storage and profile_storage, the
             caller is responsible for either passing 'load_profile=True', or manually
             loading the profile at a later stage.

--- a/pytest_anki/_fixtures.py
+++ b/pytest_anki/_fixtures.py
@@ -54,30 +54,55 @@ def anki_session(request: "FixtureRequest") -> Iterator[AnkiSession]:
     Keyword Arguments:
         base_path {str} -- Path to write Anki base folder to
             (default: system-wide temporary directory)
+        
         base_name {str} -- Base folder name (default: {"anki_base"})
+        
         profile_name {str} -- User profile name (default: {"__Temporary Test User__"})
+        
         keep_profile {bool} -- Whether to preserve profile at context exit
             (default: {False})
+        
         load_profile {bool} -- Whether to preload Anki user profile (with collection)
             (default: {False})
+        
         force_early_profile_load {bool} -- Whether to load Anki profile at app
             initialization time (without collection). Replicates the behavior when
             passing profile as a CLI argument (default: {False})
+        
         lang {str} -- Language to use for the user profile (default: {"en_US"})
+        
         packed_addons {Optional[List[PathLike]]}: List of paths to .ankiaddon-packaged
             add-ons that should be installed ahead of starting Anki
+        
         unpacked_addons {Optional[List[Tuple[str, PathLike]]]}:
             List of unpacked add-ons that should be installed ahead of starting Anki.
             Add-ons need to be specified as tuple of the add-on package name under which
             to install the add-on, and the path to the source folder (the package
             folder containing the add-on __init__.py)
+        
         addon_configs {Optional[List[Tuple[str, Dict[str, Any]]]]}:
             List of add-on package names and config values to set the user configuration
             for the specified add-on to. Useful for simulating specific config set-ups.
             Each list member needs to be specified as a tuple of add-on package name
             and dictionary of user configuration values to set.
-
-    # https://docs.pytest.org/en/latest/reference.html#request
+        
+        preset_anki_state Optional[PresetAnkiState]:
+            Allows pre-configuring Anki object state, as described by a PresetAnkiState
+            dataclass. This includes the three main configuration storages used by
+            add-ons, mw.col.conf (colconf_strage), mw.pm.profile (profile_storage),
+            and mw.pm.meta (meta_storage).
+            
+            The provided data is applied on top of the existing data in each case
+            (i.e. in the same way as dict.update(new_data) would).
+            
+            State specified in this manner is guaranteed to be pre-configured ahead of
+            add-on load time (in the case of meta_storage), or ahead of
+            gui_hooks.profile_did_open fire time (in the case of colconf_storage and
+            profile_storage).
+            
+            Please note that, in the case of colconf_storage and profile_storage, the
+            caller is responsible for either passing 'load_profile=True', or manually
+            loading the profile at a later stage.
     """
 
     indirect_parameters: Optional[Dict[str, Any]] = getattr(request, "param", None)

--- a/pytest_anki/_launch.py
+++ b/pytest_anki/_launch.py
@@ -104,29 +104,55 @@ def anki_running(
     Keyword Arguments:
         base_path {str} -- Path to write Anki base folder to
             (default: system-wide temporary directory)
+        
         base_name {str} -- Base folder name (default: {"anki_base"})
+        
         profile_name {str} -- User profile name (default: {"__Temporary Test User__"})
+        
         keep_profile {bool} -- Whether to preserve profile at context exit
             (default: {False})
+        
         load_profile {bool} -- Whether to preload Anki user profile (with collection)
             (default: {False})
+        
         force_early_profile_load {bool} -- Whether to load Anki profile at app
             initialization time (without collection). Replicates the behavior when
             passing profile as a CLI argument (default: {False})
+        
         lang {str} -- Language to use for the user profile (default: {"en_US"})
+        
         packed_addons {Optional[List[PathLike]]}: List of paths to .ankiaddon-packaged
             add-ons that should be installed ahead of starting Anki
+        
         unpacked_addons {Optional[List[Tuple[str, PathLike]]]}:
             List of unpacked add-ons that should be installed ahead of starting Anki.
             Add-ons need to be specified as tuple of the add-on package name under which
             to install the add-on, and the path to the source folder (the package
             folder containing the add-on __init__.py)
+        
         addon_configs {Optional[List[Tuple[str, Dict[str, Any]]]]}:
             List of add-on package names and config values to set the user configuration
             for the specified add-on to. Useful for simulating specific config set-ups.
             Each list member needs to be specified as a tuple of add-on package name
             and dictionary of user configuration values to set.
-        anki_configs
+        
+        preset_anki_state Optional[PresetAnkiState]:
+            Allows pre-configuring Anki object state, as described by a PresetAnkiState
+            dataclass. This includes the three main configuration storages used by
+            add-ons, mw.col.conf (colconf_strage), mw.pm.profile (profile_storage),
+            and mw.pm.meta (meta_storage).
+            
+            The provided data is applied on top of the existing data in each case
+            (i.e. in the same way as dict.update(new_data) would).
+            
+            State specified in this manner is guaranteed to be pre-configured ahead of
+            add-on load time (in the case of meta_storage), or ahead of
+            gui_hooks.profile_did_open fire time (in the case of colconf_storage and
+            profile_storage).
+            
+            Please note that, in the case of colconf_storage and profile_storage, the
+            caller is responsible for either passing 'load_profile=True', or manually
+            loading the profile at a later stage.
 
     Returns:
         Iterator[AnkiSession] -- [description]

--- a/pytest_anki/_launch.py
+++ b/pytest_anki/_launch.py
@@ -78,10 +78,10 @@ def temporary_user(
 def base_directory(base_path: str, base_name: str, keep: bool) -> Iterator[str]:
     if not os.path.isdir(base_path):
         os.mkdir(base_path)
-    path = tempfile.mkdtemp(prefix=f"{base_name}_", dir=base_path)
-    yield path
+    anki_base_dir = tempfile.mkdtemp(prefix=f"{base_name}_", dir=base_path)
+    yield anki_base_dir
     if not keep:
-        shutil.rmtree(path)
+        shutil.rmtree(anki_base_dir)
 
 
 @contextmanager

--- a/pytest_anki/_launch.py
+++ b/pytest_anki/_launch.py
@@ -42,6 +42,7 @@ from ._patch import patch_anki, post_ui_setup_callback_factory
 from ._session import AnkiSession
 from ._types import PathLike
 from ._util import nullcontext
+from ._anki import AnkiStorageObject
 
 
 @contextmanager
@@ -96,6 +97,7 @@ def anki_running(
     packed_addons: Optional[List[PathLike]] = None,
     unpacked_addons: Optional[List[Tuple[str, PathLike]]] = None,
     addon_configs: Optional[List[Tuple[str, Dict[str, Any]]]] = None,
+    anki_configs: Optional[List[Tuple[AnkiStorageObject, Dict[str, Any]]]] = None
 ) -> Iterator[AnkiSession]:
     """Context manager that safely launches an Anki session, cleaning up after itself
 
@@ -124,6 +126,7 @@ def anki_running(
             for the specified add-on to. Useful for simulating specific config set-ups.
             Each list member needs to be specified as a tuple of add-on package name
             and dictionary of user configuration values to set.
+        anki_configs 
 
     Returns:
         Iterator[AnkiSession] -- [description]
@@ -144,6 +147,7 @@ def anki_running(
             packed_addons=packed_addons,
             unpacked_addons=unpacked_addons,
             addon_configs=addon_configs,
+            anki_configs=anki_configs
         )
 
         with patch_anki(post_ui_setup_callback=post_ui_setup_callback):

--- a/pytest_anki/_launch.py
+++ b/pytest_anki/_launch.py
@@ -98,15 +98,15 @@ def anki_running(
 
     Keyword Arguments:
         base_path {str} -- Path to write Anki base folder to
-                           (default: {tempfile.gettempdir()})
+            (default: system-wide temporary directory)
         base_name {str} -- Base folder name (default: {"anki_base"})
         profile_name {str} -- User profile name (default: {"__Temporary Test User__"})
         keep_profile {bool} -- Whether to preserve profile at context exit
-                               (default: {False})
+            (default: {False})
         load_profile {bool} -- Whether to preload Anki user profile (with collection)
-                               (default: {False})
-        force_early_profile_load {bool} -- Whether to load Anki profile
-            (without collection) at app init time. Replicates the behavior when
+            (default: {False})
+        force_early_profile_load {bool} -- Whether to load Anki profile at app
+            initialization time (without collection). Replicates the behavior when
             passing profile as a CLI argument (default: {False})
         lang {str} -- Language to use for the user profile (default: {"en_US"})
         packed_addons {Optional[List[PathLike]]}: List of paths to .ankiaddon-packaged

--- a/pytest_anki/_launch.py
+++ b/pytest_anki/_launch.py
@@ -34,7 +34,7 @@ import os
 import shutil
 import tempfile
 from contextlib import contextmanager
-from typing import Iterator, List, Optional, Tuple, Dict, Any
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 from warnings import warn
 
 from ._errors import AnkiLaunchException

--- a/pytest_anki/_launch.py
+++ b/pytest_anki/_launch.py
@@ -34,13 +34,13 @@ import os
 import shutil
 import tempfile
 from contextlib import contextmanager
-from typing import Iterator, List, Optional
+from typing import Iterator, List, Optional, Tuple
 from warnings import warn
 
 from ._errors import AnkiLaunchException
 from ._patch import patch_anki
 from ._session import AnkiSession
-from ._types import PathLike, UnpackedAddon
+from ._types import PathLike
 from ._util import nullcontext
 
 
@@ -92,7 +92,7 @@ def anki_running(
     force_early_profile_load: bool = False,
     lang: str = "en_US",
     packed_addons: Optional[List[PathLike]] = None,
-    unpacked_addons: Optional[List[UnpackedAddon]] = None,
+    unpacked_addons: Optional[List[Tuple[PathLike, str]]] = None,
 ) -> Iterator[AnkiSession]:
     """Context manager that safely launches an Anki session, cleaning up after itself
 
@@ -111,9 +111,10 @@ def anki_running(
         lang {str} -- Language to use for the user profile (default: {"en_US"})
         packed_addons {Optional[List[PathLike]]}: List of paths to .ankiaddon-packaged
             add-ons that should be installed ahead of starting Anki
-        unpacked_addons {Optional[List[UnpackedAddons]]}: List of unpackaged add-ons
-            that should be installed ahead of starting Anki, described via the
-            UnpackagedAddon datatype as found in pytest_anki.types
+        unpacked_addons {Optional[List[Tuple[PathLike, str]]]}:
+            List of unpacked add-ons that should be installed ahead of starting Anki.
+            Add-ons need to be specified as tuple of the path to the add-on directory
+            and the package name under which they should be installed.
 
     Returns:
         Iterator[AnkiSession] -- [description]

--- a/pytest_anki/_launch.py
+++ b/pytest_anki/_launch.py
@@ -37,7 +37,7 @@ from contextlib import contextmanager
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 from warnings import warn
 
-from ._anki import PresetAnkiState, apply_anki_colconf_state, apply_anki_profile_state
+from ._anki import AnkiStateUpdate, update_anki_colconf_state, update_anki_profile_state
 from ._errors import AnkiLaunchException
 from ._patch import patch_anki, post_ui_setup_callback_factory
 from ._session import AnkiSession
@@ -97,7 +97,7 @@ def anki_running(
     packed_addons: Optional[List[PathLike]] = None,
     unpacked_addons: Optional[List[Tuple[str, PathLike]]] = None,
     addon_configs: Optional[List[Tuple[str, Dict[str, Any]]]] = None,
-    preset_anki_state: Optional[PresetAnkiState] = None,
+    preset_anki_state: Optional[AnkiStateUpdate] = None,
 ) -> Iterator[AnkiSession]:
     """Context manager that safely launches an Anki session, cleaning up after itself
 
@@ -136,7 +136,7 @@ def anki_running(
             Each list member needs to be specified as a tuple of add-on package name
             and dictionary of user configuration values to set.
 
-        preset_anki_state Optional[PresetAnkiState]:
+        preset_anki_state {Optional[pytest_anki.AnkiStateUpdate]}:
             Allows pre-configuring Anki object state, as described by a PresetAnkiState
             dataclass. This includes the three main configuration storages used by
             add-ons, mw.col.conf (colconf_strage), mw.pm.profile (profile_storage),
@@ -182,11 +182,11 @@ def anki_running(
         def profile_loaded_callback():
             if not aqt.mw or not preset_anki_state:
                 return
-            apply_anki_profile_state(
-                main_window=aqt.mw, preset_anki_state=preset_anki_state
+            update_anki_profile_state(
+                main_window=aqt.mw, anki_state_update=preset_anki_state
             )
-            apply_anki_colconf_state(
-                main_window=aqt.mw, preset_anki_state=preset_anki_state
+            update_anki_colconf_state(
+                main_window=aqt.mw, anki_state_update=preset_anki_state
             )
 
         if preset_anki_state and (

--- a/pytest_anki/_launch.py
+++ b/pytest_anki/_launch.py
@@ -37,12 +37,12 @@ from contextlib import contextmanager
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 from warnings import warn
 
+from ._anki import PresetAnkiState, apply_anki_colconf_state, apply_anki_profile_state
 from ._errors import AnkiLaunchException
 from ._patch import patch_anki, post_ui_setup_callback_factory
 from ._session import AnkiSession
 from ._types import PathLike
 from ._util import nullcontext
-from ._anki import PresetAnkiState, apply_anki_colconf_state, apply_anki_profile_state
 
 
 @contextmanager
@@ -104,52 +104,52 @@ def anki_running(
     Keyword Arguments:
         base_path {str} -- Path to write Anki base folder to
             (default: system-wide temporary directory)
-        
+
         base_name {str} -- Base folder name (default: {"anki_base"})
-        
+
         profile_name {str} -- User profile name (default: {"__Temporary Test User__"})
-        
+
         keep_profile {bool} -- Whether to preserve profile at context exit
             (default: {False})
-        
+
         load_profile {bool} -- Whether to preload Anki user profile (with collection)
             (default: {False})
-        
+
         force_early_profile_load {bool} -- Whether to load Anki profile at app
             initialization time (without collection). Replicates the behavior when
             passing profile as a CLI argument (default: {False})
-        
+
         lang {str} -- Language to use for the user profile (default: {"en_US"})
-        
+
         packed_addons {Optional[List[PathLike]]}: List of paths to .ankiaddon-packaged
             add-ons that should be installed ahead of starting Anki
-        
+
         unpacked_addons {Optional[List[Tuple[str, PathLike]]]}:
             List of unpacked add-ons that should be installed ahead of starting Anki.
             Add-ons need to be specified as tuple of the add-on package name under which
             to install the add-on, and the path to the source folder (the package
             folder containing the add-on __init__.py)
-        
+
         addon_configs {Optional[List[Tuple[str, Dict[str, Any]]]]}:
             List of add-on package names and config values to set the user configuration
             for the specified add-on to. Useful for simulating specific config set-ups.
             Each list member needs to be specified as a tuple of add-on package name
             and dictionary of user configuration values to set.
-        
+
         preset_anki_state Optional[PresetAnkiState]:
             Allows pre-configuring Anki object state, as described by a PresetAnkiState
             dataclass. This includes the three main configuration storages used by
             add-ons, mw.col.conf (colconf_strage), mw.pm.profile (profile_storage),
             and mw.pm.meta (meta_storage).
-            
+
             The provided data is applied on top of the existing data in each case
             (i.e. in the same way as dict.update(new_data) would).
-            
+
             State specified in this manner is guaranteed to be pre-configured ahead of
             add-on load time (in the case of meta_storage), or ahead of
             gui_hooks.profile_did_open fire time (in the case of colconf_storage and
             profile_storage).
-            
+
             Please note that, in the case of colconf_storage and profile_storage, the
             caller is responsible for either passing 'load_profile=True', or manually
             loading the profile at a later stage.
@@ -162,8 +162,7 @@ def anki_running(
     """
 
     import aqt
-    from aqt import gui_hooks
-    from aqt import _run
+    from aqt import _run, gui_hooks
 
     with base_directory(base_path, base_name, keep_profile) as anki_base_dir:
 

--- a/pytest_anki/_patch.py
+++ b/pytest_anki/_patch.py
@@ -53,8 +53,8 @@ from ._addons import (
     install_addon_from_folder,
     install_addon_from_package,
 )
-from ._types import PathLike
 from ._anki import PresetAnkiState, apply_anki_meta_state
+from ._types import PathLike
 
 PostUISetupCallbackType = Callable[[AnkiQt], None]
 

--- a/pytest_anki/_patch.py
+++ b/pytest_anki/_patch.py
@@ -54,6 +54,7 @@ from ._addons import (
     install_addon_from_package,
 )
 from ._types import PathLike
+from ._anki import AnkiStorageObject, set_anki_object_data
 
 PostUISetupCallbackType = Callable[[AnkiQt], None]
 
@@ -63,6 +64,7 @@ def post_ui_setup_callback_factory(
     packed_addons: Optional[List[PathLike]] = None,
     unpacked_addons: Optional[List[Tuple[str, PathLike]]] = None,
     addon_configs: Optional[List[Tuple[str, Dict[str, Any]]]] = None,
+    anki_configs: Optional[List[Tuple[AnkiStorageObject, Dict[str, Any]]]] = None,
 ):
     def post_ui_setup_callback(main_window: AnkiQt):
         """Initialize add-on manager, install add-ons, load add-ons"""
@@ -88,6 +90,12 @@ def post_ui_setup_callback_factory(
                     anki_base_dir=anki_base_dir,
                     package_name=package_name,
                     user_config=config_values,
+                )
+
+        if anki_configs:
+            for storage_object, data in anki_configs:
+                set_anki_object_data(
+                    main_window=main_window, storage_object=storage_object, data=data
                 )
 
         main_window.addonManager.loadAddons()

--- a/pytest_anki/_patch.py
+++ b/pytest_anki/_patch.py
@@ -34,7 +34,7 @@
 import uuid
 from argparse import Namespace
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Callable, Iterator, List, Optional, Tuple, Dict
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Tuple
 from unittest.mock import Mock
 
 import aqt
@@ -48,12 +48,12 @@ if TYPE_CHECKING:
     from anki.collection import Collection
     from aqt.profiles import ProfileManager as ProfileManagerType
 
-from ._types import PathLike
 from ._addons import (
+    create_addon_config,
     install_addon_from_folder,
     install_addon_from_package,
-    create_addon_config,
 )
+from ._types import PathLike
 
 PostUISetupCallbackType = Callable[[AnkiQt], None]
 

--- a/pytest_anki/_patch.py
+++ b/pytest_anki/_patch.py
@@ -53,7 +53,7 @@ from ._addons import (
     install_addon_from_folder,
     install_addon_from_package,
 )
-from ._anki import PresetAnkiState, apply_anki_meta_state
+from ._anki import AnkiStateUpdate, update_anki_meta_state
 from ._types import PathLike
 
 PostUISetupCallbackType = Callable[[AnkiQt], None]
@@ -64,7 +64,7 @@ def post_ui_setup_callback_factory(
     packed_addons: Optional[List[PathLike]] = None,
     unpacked_addons: Optional[List[Tuple[str, PathLike]]] = None,
     addon_configs: Optional[List[Tuple[str, Dict[str, Any]]]] = None,
-    preset_anki_state: Optional[PresetAnkiState] = None,
+    preset_anki_state: Optional[AnkiStateUpdate] = None,
 ):
     def post_ui_setup_callback(main_window: AnkiQt):
         """Initialize add-on manager, install add-ons, load add-ons"""
@@ -93,8 +93,8 @@ def post_ui_setup_callback_factory(
                 )
 
         if preset_anki_state and preset_anki_state.meta_storage:
-            apply_anki_meta_state(
-                main_window=main_window, preset_anki_state=preset_anki_state
+            update_anki_meta_state(
+                main_window=main_window, anki_state_update=preset_anki_state
             )
 
         main_window.addonManager.loadAddons()

--- a/pytest_anki/_patch.py
+++ b/pytest_anki/_patch.py
@@ -68,8 +68,8 @@ def custom_init_factory(
         for unpacked_addon in unpacked_addons:
             install_addon_from_folder(
                 base_path=base_path,
-                addon_path=unpacked_addon.path,
-                package_name=unpacked_addon.package_name,
+                addon_path=unpacked_addon[0],
+                package_name=unpacked_addon[1],
             )
 
         main_window.addonManager.loadAddons()

--- a/pytest_anki/_patch.py
+++ b/pytest_anki/_patch.py
@@ -54,7 +54,7 @@ from ._addons import (
     install_addon_from_package,
 )
 from ._types import PathLike
-from ._anki import AnkiStorageObject, set_anki_object_data
+from ._anki import PresetAnkiState, apply_anki_meta_state
 
 PostUISetupCallbackType = Callable[[AnkiQt], None]
 
@@ -64,7 +64,7 @@ def post_ui_setup_callback_factory(
     packed_addons: Optional[List[PathLike]] = None,
     unpacked_addons: Optional[List[Tuple[str, PathLike]]] = None,
     addon_configs: Optional[List[Tuple[str, Dict[str, Any]]]] = None,
-    anki_configs: Optional[List[Tuple[AnkiStorageObject, Dict[str, Any]]]] = None,
+    preset_anki_state: Optional[PresetAnkiState] = None,
 ):
     def post_ui_setup_callback(main_window: AnkiQt):
         """Initialize add-on manager, install add-ons, load add-ons"""
@@ -92,11 +92,10 @@ def post_ui_setup_callback_factory(
                     user_config=config_values,
                 )
 
-        if anki_configs:
-            for storage_object, data in anki_configs:
-                set_anki_object_data(
-                    main_window=main_window, storage_object=storage_object, data=data
-                )
+        if preset_anki_state and preset_anki_state.meta_storage:
+            apply_anki_meta_state(
+                main_window=main_window, preset_anki_state=preset_anki_state
+            )
 
         main_window.addonManager.loadAddons()
 

--- a/pytest_anki/_patch.py
+++ b/pytest_anki/_patch.py
@@ -34,7 +34,7 @@
 import uuid
 from argparse import Namespace
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Iterator, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Iterator, List, Optional, Tuple, Dict
 from unittest.mock import Mock
 
 import aqt
@@ -43,37 +43,59 @@ from aqt.mediasync import MediaSyncer
 from aqt.qt import QMainWindow
 from aqt.taskman import TaskManager
 
-from ._addons import install_addon_from_folder, install_addon_from_package
-from ._types import PathLike, UnpackedAddon
-
 if TYPE_CHECKING:
     from anki._backend import RustBackend
     from anki.collection import Collection
     from aqt.profiles import ProfileManager as ProfileManagerType
 
+from ._types import PathLike
+from ._addons import (
+    install_addon_from_folder,
+    install_addon_from_package,
+    create_addon_config,
+)
 
-def custom_init_factory(
-    packed_addons: List[PathLike],
-    unpacked_addons: List[UnpackedAddon],
-    base_path: PathLike,
+PostUISetupCallbackType = Callable[[AnkiQt], None]
+
+
+def post_ui_setup_callback_factory(
+    anki_base_dir: PathLike,
+    packed_addons: Optional[List[PathLike]] = None,
+    unpacked_addons: Optional[List[Tuple[str, PathLike]]] = None,
+    addon_configs: Optional[List[Tuple[str, Dict[str, Any]]]] = None,
 ):
-    def _setup_addons(main_window: AnkiQt):
+    def post_ui_setup_callback(main_window: AnkiQt):
+        """Initialize add-on manager, install add-ons, load add-ons"""
         main_window.addonManager = aqt.addons.AddonManager(main_window)
 
-        for packed_addon in packed_addons:
-            install_addon_from_package(
-                addon_manager=main_window.addonManager, addon_path=packed_addon
-            )
+        if packed_addons:
+            for packed_addon in packed_addons:
+                install_addon_from_package(
+                    addon_manager=main_window.addonManager, addon_path=packed_addon
+                )
 
-        for unpacked_addon in unpacked_addons:
-            install_addon_from_folder(
-                base_path=base_path,
-                addon_path=unpacked_addon[0],
-                package_name=unpacked_addon[1],
-            )
+        if unpacked_addons:
+            for package_name, addon_path in unpacked_addons:
+                install_addon_from_folder(
+                    anki_base_dir=anki_base_dir,
+                    package_name=package_name,
+                    addon_path=addon_path,
+                )
+
+        if addon_configs:
+            for package_name, config_values in addon_configs:
+                create_addon_config(
+                    anki_base_dir=anki_base_dir,
+                    package_name=package_name,
+                    user_config=config_values,
+                )
 
         main_window.addonManager.loadAddons()
 
+    return post_ui_setup_callback
+
+
+def custom_init_factory(post_ui_setup_callback: PostUISetupCallbackType):
     def custom_init(
         main_window: AnkiQt,
         app: aqt.AnkiApp,
@@ -97,21 +119,22 @@ def custom_init_factory(
             main_window.taskman = TaskManager()  # type: ignore
 
         main_window.media_syncer = MediaSyncer(main_window)
-        
+
         try:  # 2.1.45+
             from aqt.flags import FlagManager
 
             main_window.flags = FlagManager(main_window)
         except (ImportError, ModuleNotFoundError):
             pass
-        
+
         aqt.mw = main_window
         main_window.app = app
         main_window.pm = profileManager
         main_window.safeMode = False  # disable safe mode, of no use to us
         main_window.setupUI()
-        _setup_addons(main_window)
-        
+
+        post_ui_setup_callback(main_window)
+
         try:  # 2.1.28+
             main_window.finish_ui_setup()
         except AttributeError:
@@ -122,9 +145,7 @@ def custom_init_factory(
 
 @contextmanager
 def patch_anki(
-    base_dir: PathLike,
-    packed_addons: List[PathLike],
-    unpacked_addons: List[UnpackedAddon],
+    post_ui_setup_callback: PostUISetupCallbackType,
 ) -> Iterator[str]:
     """Patch Anki to:
     - allow more fine-grained control of test execution environment
@@ -142,9 +163,7 @@ def patch_anki(
     old_errorHandler = errors.ErrorHandler
 
     patched_ankiqt_init = custom_init_factory(
-        packed_addons=packed_addons,
-        unpacked_addons=unpacked_addons,
-        base_path=base_dir,
+        post_ui_setup_callback=post_ui_setup_callback
     )
 
     AnkiQt.__init__ = patched_ankiqt_init  # type: ignore

--- a/pytest_anki/_session.py
+++ b/pytest_anki/_session.py
@@ -30,19 +30,20 @@
 
 from contextlib import contextmanager
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional
 
 from anki.importing.apkg import AnkiPackageImporter
 
 from ._addons import ConfigPaths, create_addon_config
+from ._anki import (
+    AnkiStorageObject,
+    PresetAnkiState,
+    apply_anki_state,
+    get_anki_object,
+    get_collection,
+)
 from ._errors import AnkiSessionError
 from ._types import PathLike
-from ._anki import (
-    get_collection,
-    set_anki_object_data,
-    get_anki_object,
-    AnkiStorageObject,
-)
 
 if TYPE_CHECKING:
     from anki.collection import Collection
@@ -216,19 +217,5 @@ class AnkiSession:
 
     # Anki config object handling ####
 
-    def set_anki_object_data(
-        self, storage_object: AnkiStorageObject, data: dict
-    ) -> Union[Dict[str, Any], "ConfigManager"]:
-        """Update the data of a specified Anki storage object
-
-        This may be used to simulate specific Anki and/or add-on states
-        during testing."""
-        return set_anki_object_data(
-            main_window=self._mw, storage_object=storage_object, data=data
-        )
-
-    def get_anki_object(
-        self, storage_object: AnkiStorageObject
-    ) -> Union[Dict[str, Any], "ConfigManager"]:
-        """Get Anki object for specified AnkiStorageObject type"""
-        return get_anki_object(main_window=self._mw, storage_object=storage_object)
+    def apply_anki_state(self, preset_anki_state: PresetAnkiState):
+        apply_anki_state(main_window=self._mw, preset_anki_state=preset_anki_state)

--- a/pytest_anki/_session.py
+++ b/pytest_anki/_session.py
@@ -31,6 +31,7 @@
 from contextlib import contextmanager
 from enum import Enum
 from pathlib import Path
+from types import ModuleType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -42,7 +43,6 @@ from typing import (
     Optional,
     Union,
 )
-from types import ModuleType
 
 from anki.importing.apkg import AnkiPackageImporter
 

--- a/pytest_anki/_session.py
+++ b/pytest_anki/_session.py
@@ -36,10 +36,8 @@ from anki.importing.apkg import AnkiPackageImporter
 
 from ._addons import ConfigPaths, create_addon_config
 from ._anki import (
-    AnkiStorageObject,
-    PresetAnkiState,
-    apply_anki_state,
-    get_anki_object,
+    AnkiStateUpdate,
+    update_anki_state,
     get_collection,
 )
 from ._errors import AnkiSessionError
@@ -47,7 +45,6 @@ from ._types import PathLike
 
 if TYPE_CHECKING:
     from anki.collection import Collection
-    from anki.config import ConfigManager
     from aqt import AnkiApp
     from aqt.main import AnkiQt
 
@@ -217,5 +214,5 @@ class AnkiSession:
 
     # Anki config object handling ####
 
-    def apply_anki_state(self, preset_anki_state: PresetAnkiState):
-        apply_anki_state(main_window=self._mw, preset_anki_state=preset_anki_state)
+    def update_anki_state(self, anki_state_update: AnkiStateUpdate):
+        update_anki_state(main_window=self._mw, anki_state_update=anki_state_update)

--- a/pytest_anki/_types.py
+++ b/pytest_anki/_types.py
@@ -29,13 +29,8 @@
 # Any modifications to this file must keep this entire header intact.
 
 
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Union
+from typing import Tuple, Union
 
 PathLike = Union[str, Path]
-
-@dataclass
-class UnpackedAddon:
-    path: PathLike
-    package_name: str
+UnpackedAddon = Tuple[PathLike, str]  # path to add-on folder, package name

--- a/pytest_anki/_util.py
+++ b/pytest_anki/_util.py
@@ -41,7 +41,7 @@ def nullcontext() -> Iterator[None]:
 
 def create_json(path: Union[str, Path], data: dict) -> str:
     """Creates a JSON file at the specified path, preloading it with the specified data.
-    
+
     Arguments:
         path {Union[str, Path]} -- path to JSON file
         data {dict} -- data to write to file


### PR DESCRIPTION
Allows loading add-ons via the `anki_session` fixture with pre-specified configuration values set.

----

_Note: This patch was written under commission for AMBOSS MD Inc. Its rights of use and exploitation lie with AMBOSS MD Inc. It is submitted as a contribution to pytest-anki under pytest-anki's license terms (see LICENSE file)._
