### PR TITLE
Add support for testing web views via remote debugging

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,10 +52,12 @@ jobs:
         run: |
           sudo apt-get install libqt5gui5
 
-      - name: setup-chromedriver
-        uses: nanasess/setup-chromedriver@v1.0.1
-        with:
-          chromedriver-version: ${{ matrix.chrome }}
+      - name: Setup chromedriver
+        run:
+          wget -c -nc --retry-connrefused --tries=0 https://chromedriver.storage.googleapis.com/${{ matrix.chrome }}/chromedriver_linux64.zip
+          unzip -o -q chromedriver_${ARCH}.zip
+          sudo mv chromedriver /usr/local/bin/chromedriver
+          rm chromedriver_linux64.zip
 
       - name: Checkout pytest-anki
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup chromedriver
         run:
           wget -c -nc --retry-connrefused --tries=0 https://chromedriver.storage.googleapis.com/${{ matrix.chrome }}/chromedriver_linux64.zip
-          unzip -o -q chromedriver_${ARCH}.zip
+          unzip -o -q chromedriver_linux64.zip
           sudo mv chromedriver /usr/local/bin/chromedriver
           rm chromedriver_linux64.zip
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,9 +53,14 @@ jobs:
           sudo apt-get install libqt5gui5
 
       - name: Setup chromedriver
-        uses: nanasess/setup-chromedriver@master
-        with:
-          chromedriver-version: ${{ matrix.chrome }}
+        run: |
+          chrome_version=${{ matrix.chrome }}
+          truncated_version=${chrome_version%.*}
+          driver_version=$(curl --location --fail --retry 10 "http://chromedriver.storage.googleapis.com/LATEST_RELEASE_${truncated_version}")
+          wget -c -nc --retry-connrefused --tries=0 "https://chromedriver.storage.googleapis.com/${driver_version}/chromedriver_linux64.zip"
+          unzip -o -q "chromedriver_linux64.zip"
+          sudo mv chromedriver /usr/local/bin/chromedriver
+          rm "chromedriver_linux64.zip"
 
       - name: Checkout pytest-anki
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,26 +15,34 @@ jobs:
     strategy:
       matrix:
         include:
+          # Version matrix follows static macOS builds as closely as possible.
+          # Some Qt package versions are not available on PyPI, so we need to make
+          # compromises here and there.
           - anki: 2.1.47
-            python: 3.8.1
-            pyqt: 5.15.1
-            pyqtwebengine: 5.15.1
-          - anki: 2.1.44
-            python: 3.8.1
+            python: 3.8.6
             pyqt: 5.14.2
             pyqtwebengine: 5.14.0
+            chrome: 77.0.3865.129
+          - anki: 2.1.44
+            python: 3.8.6
+            pyqt: 5.14.2
+            pyqtwebengine: 5.14.0
+            chrome: 77.0.3865.129
           - anki: 2.1.35
             python: 3.8.0
             pyqt: 5.14.2
             pyqtwebengine: 5.14.0
+            chrome: 77.0.3865.129
           - anki: 2.1.28
             python: 3.8.0
             pyqt: 5.15.0
             pyqtwebengine: 5.15.0
+            chrome: 80.0.3987.163
           - anki: 2.1.26
             python: 3.8.0
             pyqt: 5.13.1
             pyqtwebengine: 5.13.1
+            chrome: 73.0.3683.105
 
     steps:
       # Qt5 requires a number of X11-related dependencies to be installed system-wide.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,11 +53,9 @@ jobs:
           sudo apt-get install libqt5gui5
 
       - name: Setup chromedriver
-        run:
-          wget -c -nc --retry-connrefused --tries=0 https://chromedriver.storage.googleapis.com/${{ matrix.chrome }}/chromedriver_linux64.zip
-          unzip -o -q chromedriver_linux64.zip
-          sudo mv chromedriver /usr/local/bin/chromedriver
-          rm chromedriver_linux64.zip
+        uses: nanasess/setup-chromedriver@master
+        with:
+          chromedriver-version: ${{ matrix.chrome }}
 
       - name: Checkout pytest-anki
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,11 @@ jobs:
         run: |
           sudo apt-get install libqt5gui5
 
+      - name: setup-chromedriver
+        uses: nanasess/setup-chromedriver@v1.0.1
+        with:
+          chromedriver-version: ${{ matrix.chrome }}
+
       - name: Checkout pytest-anki
         uses: actions/checkout@v2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,9 +85,9 @@ jobs:
       matrix:
         include:
           - anki: 2.1.47
-            python: 3.8.1
-            pyqt: 5.15.1
-            pyqtwebengine: 5.15.1
+            python: 3.8.6
+            pyqt: 5.14.2
+            pyqtwebengine: 5.14.0
     steps:
       - name: Checkout pytest-anki
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ lint:
 # Run code formatters
 format:
 	python -m isort $(MONITORED_FOLDERS)
+	python -m autoflake --recursive --in-place --remove-all-unused-imports $(MONITORED_FOLDERS)
 	python -m black $(MONITORED_FOLDERS)
 
 # Build project

--- a/poetry.lock
+++ b/poetry.lock
@@ -741,6 +741,14 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "types-requests"
+version = "2.25.6"
+description = "Typing stubs for requests"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "typing-extensions"
 version = "3.10.0.2"
 description = "Backported and Experimental Type Hints for Python 3.5+"
@@ -811,7 +819,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "82da908314a0fdc34a2781ae74adea961a004576ec552d181445eab34f497de1"
+content-hash = "9f7d057c3b63f20cf396a77218f8cae2a4c36969e97bb3f3cf0a64008968b883"
 
 [metadata.files]
 anki = [
@@ -1328,6 +1336,10 @@ toml = [
 tomli = [
     {file = "tomli-1.2.1-py3-none-any.whl", hash = "sha256:8dd0e9524d6f386271a36b41dbf6c57d8e32fd96fd22b6584679dc569d20899f"},
     {file = "tomli-1.2.1.tar.gz", hash = "sha256:a5b75cb6f3968abb47af1b40c1819dc519ea82bcc065776a866e8d74c5ca9442"},
+]
+types-requests = [
+    {file = "types-requests-2.25.6.tar.gz", hash = "sha256:e21541c0f55c066c491a639309159556dd8c5833e49fcde929c4c47bdb0002ee"},
+    {file = "types_requests-2.25.6-py3-none-any.whl", hash = "sha256:a5a305b43ea57bf64d6731f89816946a405b591eff6de28d4c0fd58422cee779"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -677,6 +677,17 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
+name = "selenium"
+version = "3.141.0"
+description = "Python bindings for Selenium"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+urllib3 = "*"
+
+[[package]]
 name = "send2trash"
 version = "1.8.0"
 description = "Send file to trash natively under Mac OS X, Windows and Linux."
@@ -800,7 +811,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "e1a46d3a7b2743f76ee39e9c3f491996213aa717ab0f24ac373df34ede245c3c"
+content-hash = "82da908314a0fdc34a2781ae74adea961a004576ec552d181445eab34f497de1"
 
 [metadata.files]
 anki = [
@@ -1290,6 +1301,10 @@ regex = [
 requests = [
     {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
     {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
+]
+selenium = [
+    {file = "selenium-3.141.0-py2.py3-none-any.whl", hash = "sha256:2d7131d7bc5a5b99a2d9b04aaf2612c411b03b8ca1b1ee8d3de5845a9be2cb3c"},
+    {file = "selenium-3.141.0.tar.gz", hash = "sha256:deaf32b60ad91a4611b98d8002757f29e6f2c2d5fcaf202e1c9ad06d6772300d"},
 ]
 send2trash = [
     {file = "Send2Trash-1.8.0-py3-none-any.whl", hash = "sha256:f20eaadfdb517eaca5ce077640cb261c7d2698385a6a0f072a4a5447fd49fa08"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -590,7 +590,7 @@ pytest = ">=3.10"
 name = "pytest-qt"
 version = "4.0.2"
 description = "pytest support for PyQt and PySide applications"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -800,7 +800,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "58442f2900445000768eed9fa8a5f240ef5ddf87ea4dec6b842205b98332fce4"
+content-hash = "e1a46d3a7b2743f76ee39e9c3f491996213aa717ab0f24ac373df34ede245c3c"
 
 [metadata.files]
 anki = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -81,6 +81,17 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
 
 [[package]]
+name = "autoflake"
+version = "1.4"
+description = "Removes unused imports and unused variables"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pyflakes = ">=1.1.0"
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.9.3"
 description = "Screen-scraping library"
@@ -517,6 +528,17 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "pyqt5-stubs"
+version = "5.15.2.0"
+description = "PEP561 stub files for the PyQt5 framework"
+category = "dev"
+optional = false
+python-versions = ">= 3.5"
+
+[package.extras]
+build = ["docker (==4.2.0)"]
+
+[[package]]
 name = "pyqtwebengine"
 version = "5.15.4"
 description = "Python bindings for the Qt WebEngine framework"
@@ -819,7 +841,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "9f7d057c3b63f20cf396a77218f8cae2a4c36969e97bb3f3cf0a64008968b883"
+content-hash = "3dbfe22b11b5fa8c07b69b657a89fced99a51122d864d8e173f61bdffd3b979a"
 
 [metadata.files]
 anki = [
@@ -841,6 +863,9 @@ atomicwrites = [
 attrs = [
     {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
     {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
+]
+autoflake = [
+    {file = "autoflake-1.4.tar.gz", hash = "sha256:61a353012cff6ab94ca062823d1fb2f692c4acda51c76ff83a8d77915fba51ea"},
 ]
 beautifulsoup4 = [
     {file = "beautifulsoup4-4.9.3-py2-none-any.whl", hash = "sha256:4c98143716ef1cb40bf7f39a8e3eec8f8b009509e74904ba3a7b315431577e35"},
@@ -1185,6 +1210,10 @@ pyqt5-sip = [
     {file = "PyQt5_sip-12.9.0-cp39-cp39-win32.whl", hash = "sha256:4f8e05fe01d54275877c59018d8e82dcdd0bc5696053a8b830eecea3ce806121"},
     {file = "PyQt5_sip-12.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:b09f4cd36a4831229fb77c424d89635fa937d97765ec90685e2f257e56a2685a"},
     {file = "PyQt5_sip-12.9.0.tar.gz", hash = "sha256:d3e4489d7c2b0ece9d203ae66e573939f7f60d4d29e089c9f11daa17cfeaae32"},
+]
+pyqt5-stubs = [
+    {file = "PyQt5-stubs-5.15.2.0.tar.gz", hash = "sha256:dc0dea66f02fe297fb0cddd5767fbf58275b54ecb67f69ebeb994e1553bfb9b2"},
+    {file = "PyQt5_stubs-5.15.2.0-py3-none-any.whl", hash = "sha256:4b750d04ffca1bb188615d1a4e7d655a1d81d30df6ee3488f0adfe09b78e3d36"},
 ]
 pyqtwebengine = [
     {file = "PyQtWebEngine-5.15.4-cp36.cp37.cp38.cp39-abi3-macosx_10_13_intel.whl", hash = "sha256:aecbaf8827ad96d04085285988d8199d8d59018eec181412467252a6ff03aab0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ pytest-xvfb = "^2.0.0"
 anki = ">=2.1.28"
 aqt = ">=2.1.28"
 pytest-qt = "^4.0.2"
+selenium = "^3.141.0"
 
 [tool.poetry.dev-dependencies]
 black = "^21.7b0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ pylint = "^2.10.2"
 mypy = "^0.910"
 isort = "^5.9.3"
 flake8 = "^3.9.2"
+requests = "^2.26.0"
+types-requests = "^2.25.6"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ pytest-xdist = "^2.3.0"
 pytest-xvfb = "^2.0.0"
 anki = ">=2.1.28"
 aqt = ">=2.1.28"
+pytest-qt = "^4.0.2"
 
 [tool.poetry.dev-dependencies]
 black = "^21.7b0"
@@ -40,7 +41,6 @@ pylint = "^2.10.2"
 mypy = "^0.910"
 isort = "^5.9.3"
 flake8 = "^3.9.2"
-pytest-qt = "^4.0.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,8 @@ isort = "^5.9.3"
 flake8 = "^3.9.2"
 requests = "^2.26.0"
 types-requests = "^2.25.6"
+PyQt5-stubs = "^5.15.2"
+autoflake = "^1.4"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pytest_anki/__init__.py
+++ b/pytest_anki/__init__.py
@@ -35,7 +35,6 @@ A simple pytest plugin for testing Anki add-ons
 
 from ._anki import AnkiStateUpdate  # noqa: F401
 from ._errors import AnkiSessionError  # noqa: F401
-from ._launch import anki_running  # noqa: F401
 from ._session import AnkiSession  # noqa: F401
 
 __version__ = "1.0.0-dev.1"

--- a/pytest_anki/__init__.py
+++ b/pytest_anki/__init__.py
@@ -34,6 +34,7 @@ A simple pytest plugin for testing Anki add-ons
 """
 
 from ._anki import AnkiStateUpdate  # noqa: F401
+from ._anki import AnkiWebViews  # noqa: F401
 from ._errors import AnkiSessionError  # noqa: F401
 from ._session import AnkiSession  # noqa: F401
 

--- a/pytest_anki/__init__.py
+++ b/pytest_anki/__init__.py
@@ -33,8 +33,7 @@
 A simple pytest plugin for testing Anki add-ons
 """
 
-from ._anki import AnkiStateUpdate  # noqa: F401
-from ._anki import AnkiWebViews  # noqa: F401
+from ._anki import AnkiStateUpdate, AnkiWebViewType  # noqa: F401
 from ._errors import AnkiSessionError  # noqa: F401
 from ._session import AnkiSession  # noqa: F401
 

--- a/pytest_anki/_anki.py
+++ b/pytest_anki/_anki.py
@@ -41,6 +41,19 @@ if TYPE_CHECKING:
     from aqt.main import AnkiQt
 
 
+class AnkiWebViews(Enum):
+    main_webview = "main webview"
+    top_toolbar = "top toolbar"
+    bottom_toolbar = "bottom toolbar"
+    legacy_deck_stats = "deck stats"
+    previewer = "previewer"
+    browser_card_info = "browser card info"
+    card_layout = "card layout"
+    change_notetype = "changeNotetype"
+    find_duplicates = "find duplicates"
+    empty_cards = "empty cards"
+
+
 @dataclass
 class AnkiStateUpdate:
 

--- a/pytest_anki/_anki.py
+++ b/pytest_anki/_anki.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
     from aqt.main import AnkiQt
 
 
-class AnkiWebViews(Enum):
+class AnkiWebViewType(Enum):
     main_webview = "main webview"
     top_toolbar = "top toolbar"
     bottom_toolbar = "bottom toolbar"

--- a/pytest_anki/_launch.py
+++ b/pytest_anki/_launch.py
@@ -253,7 +253,12 @@ def anki_running(
                         raise AnkiSessionError("Main window not initialized correctly")
 
                     anki_session = AnkiSession(
-                        app=app, mw=mw, user=user_name, base=anki_base_dir
+                        app=app,
+                        mw=mw,
+                        user=user_name,
+                        base=anki_base_dir,
+                        qtbot=qtbot,
+                        web_debugging_port=web_debugging_port,
                     )
 
                     if not load_profile:

--- a/pytest_anki/_launch.py
+++ b/pytest_anki/_launch.py
@@ -83,10 +83,10 @@ def anki_running(
     profile_name: str = "User 1",
     lang: str = "en_US",
     load_profile: bool = False,
+    preset_anki_state: Optional[AnkiStateUpdate] = None,
     packed_addons: Optional[List[PathLike]] = None,
     unpacked_addons: Optional[List[Tuple[str, PathLike]]] = None,
     addon_configs: Optional[List[Tuple[str, Dict[str, Any]]]] = None,
-    preset_anki_state: Optional[AnkiStateUpdate] = None,
 ) -> Iterator[AnkiSession]:
     """Context manager that safely launches an Anki session, cleaning up after itself
 

--- a/pytest_anki/_launch.py
+++ b/pytest_anki/_launch.py
@@ -41,7 +41,11 @@ from PyQt5.QtCore import qInstallMessageHandler
 
 from ._anki import AnkiStateUpdate, update_anki_colconf_state, update_anki_profile_state
 from ._errors import AnkiSessionError
-from ._patch import patch_anki, post_ui_setup_callback_factory
+from ._patch import (
+    patch_anki,
+    post_ui_setup_callback_factory,
+    set_qt_message_handler_installer,
+)
 from ._qt import QtMessageMatcher
 from ._session import AnkiSession
 from ._types import PathLike
@@ -238,7 +242,7 @@ def anki_running(
 
                             qInstallMessageHandler(message_handler_wrapper)
 
-                        aqt.qInstallMessageHandler = install_message_handler
+                        set_qt_message_handler_installer(install_message_handler)
 
                         maybe_wait_for_web_debugging = qtbot.wait_signal(
                             qt_message_matcher.match_found
@@ -276,7 +280,7 @@ def anki_running(
                             yield anki_session
 
                     # Undo monkey-patch if applied
-                    aqt.qInstallMessageHandler = qInstallMessageHandler
+                    set_qt_message_handler_installer(qInstallMessageHandler)
 
     # NOTE: clean up does not seem to work properly in all cases,
     # so use pytest-forked for now

--- a/pytest_anki/_launch.py
+++ b/pytest_anki/_launch.py
@@ -99,7 +99,7 @@ def anki_running(
     packed_addons: Optional[List[PathLike]] = None,
     unpacked_addons: Optional[List[Tuple[str, PathLike]]] = None,
     addon_configs: Optional[List[Tuple[str, Dict[str, Any]]]] = None,
-    enable_web_debugging: bool = False,
+    enable_web_debugging: bool = True,
 ) -> Iterator[AnkiSession]:
     """Context manager that safely launches an Anki session, cleaning up after itself
 

--- a/pytest_anki/_launch.py
+++ b/pytest_anki/_launch.py
@@ -49,13 +49,6 @@ from ._types import PathLike
 if TYPE_CHECKING:
     from pytestqt.qtbot import QtBot
 
-# @contextmanager
-# def environment_set(environment: Dict[str, str]):
-#     os.environ.update(environment)
-
-#     yield os.environ
-
-#     os.environ.update(old_environ)
 
 QTWEBENGINE_REMOTE_DEBUGGING = "QTWEBENGINE_REMOTE_DEBUGGING"
 

--- a/pytest_anki/_launch.py
+++ b/pytest_anki/_launch.py
@@ -33,15 +33,21 @@
 import os
 import shutil
 import tempfile
-from contextlib import contextmanager
-from typing import Any, Dict, Iterator, List, Optional, Tuple
+from contextlib import contextmanager, nullcontext
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple
 from unittest import mock
+
+from PyQt5.QtCore import qInstallMessageHandler
 
 from ._anki import AnkiStateUpdate, update_anki_colconf_state, update_anki_profile_state
 from ._errors import AnkiSessionError
 from ._patch import patch_anki, post_ui_setup_callback_factory
+from ._qt import QtMessageMatcher
 from ._session import AnkiSession
 from ._types import PathLike
+
+if TYPE_CHECKING:
+    from pytestqt.qtbot import QtBot
 
 # @contextmanager
 # def environment_set(environment: Dict[str, str]):
@@ -50,6 +56,8 @@ from ._types import PathLike
 #     yield os.environ
 
 #     os.environ.update(old_environ)
+
+QTWEBENGINE_REMOTE_DEBUGGING = "QTWEBENGINE_REMOTE_DEBUGGING"
 
 
 @contextmanager
@@ -87,6 +95,7 @@ def base_directory(base_path: str, base_name: str) -> Iterator[str]:
 
 @contextmanager
 def anki_running(
+    qtbot: "QtBot",
     base_path: str = tempfile.gettempdir(),
     base_name: str = "anki_base",
     profile_name: str = "User 1",
@@ -158,7 +167,7 @@ def anki_running(
     """
 
     import aqt
-    from aqt import _run, gui_hooks
+    from aqt import gui_hooks
 
     with base_directory(base_path=base_path, base_name=base_name) as anki_base_dir:
 
@@ -203,16 +212,48 @@ def anki_running(
                 environment = {}
 
                 if web_debugging_port:
-                    environment["QTWEBENGINE_REMOTE_DEBUGGING"] = str(
-                        web_debugging_port
-                    )
+                    environment[QTWEBENGINE_REMOTE_DEBUGGING] = str(web_debugging_port)
 
                 with mock.patch.dict(os.environ, environment):
-                    # We don't pass in -p <profile> in order to avoid profile loading.
-                    # This helps replicate the profile availability at add-on init time
-                    # for most users. Anki will automatically open the profile at
-                    # mw.setupProfile time in single-profile setups
-                    app = _run(argv=["anki", "-b", anki_base_dir], exec=False)
+
+                    if os.environ.get(QTWEBENGINE_REMOTE_DEBUGGING):
+
+                        # We want to wait until remote debugging started to yield the
+                        # Anki session, so we monitor Qt's log for the corresponding msg
+                        qt_message_matcher = QtMessageMatcher(
+                            "Remote debugging server started successfully"
+                        )
+
+                        # On macOS, Anki does not install a custom message
+                        # handler, so we can install our own directly:
+                        qInstallMessageHandler(qt_message_matcher)
+
+                        # On Windows and Linux, we need to monkey-patch the
+                        # message handler installer to make sure that ours is
+                        # not switched out when aqt runs
+                        def install_message_handler(message_handler):
+                            def message_handler_wrapper(*args, **kwargs):
+                                qt_message_matcher(*args, **kwargs)
+                                return message_handler(*args, **kwargs)
+
+                            qInstallMessageHandler(message_handler_wrapper)
+
+                        aqt.qInstallMessageHandler = install_message_handler
+
+                        maybe_wait_for_web_debugging = qtbot.wait_signal(
+                            qt_message_matcher.match_found
+                        )
+                    else:
+                        maybe_wait_for_web_debugging = nullcontext()
+
+                    with maybe_wait_for_web_debugging:
+                        # We don't pass in -p <profile> in order to avoid
+                        # profileloading. This helps replicate the profile
+                        # availability at add-on init time for most users. Anki
+                        # will automatically open the profile at mw.setupProfile
+                        # time in single-profile setups
+                        app = aqt._run(argv=["anki", "-b", anki_base_dir], exec=False)
+
                     mw = aqt.mw
 
                     if mw is None or app is None:
@@ -228,6 +269,9 @@ def anki_running(
                     else:
                         with anki_session.profile_loaded():
                             yield anki_session
+
+                    # Undo monkey-patch if applied
+                    aqt.qInstallMessageHandler = qInstallMessageHandler
 
     # NOTE: clean up does not seem to work properly in all cases,
     # so use pytest-forked for now

--- a/pytest_anki/_launch.py
+++ b/pytest_anki/_launch.py
@@ -45,6 +45,7 @@ from ._patch import patch_anki, post_ui_setup_callback_factory
 from ._qt import QtMessageMatcher
 from ._session import AnkiSession
 from ._types import PathLike
+from ._util import find_free_port
 
 if TYPE_CHECKING:
     from pytestqt.qtbot import QtBot
@@ -98,7 +99,7 @@ def anki_running(
     packed_addons: Optional[List[PathLike]] = None,
     unpacked_addons: Optional[List[Tuple[str, PathLike]]] = None,
     addon_configs: Optional[List[Tuple[str, Dict[str, Any]]]] = None,
-    web_debugging_port: Optional[int] = None,
+    enable_web_debugging: bool = False,
 ) -> Iterator[AnkiSession]:
     """Context manager that safely launches an Anki session, cleaning up after itself
 
@@ -204,8 +205,14 @@ def anki_running(
 
                 environment = {}
 
-                if web_debugging_port:
+                if enable_web_debugging:
+                    web_debugging_port = find_free_port()
+                    print(type(web_debugging_port))
+                    if web_debugging_port is None:
+                        raise OSError("Could not find a free port for remote debugging")
                     environment[QTWEBENGINE_REMOTE_DEBUGGING] = str(web_debugging_port)
+                else:
+                    web_debugging_port = None
 
                 with mock.patch.dict(os.environ, environment):
 

--- a/pytest_anki/_patch.py
+++ b/pytest_anki/_patch.py
@@ -188,3 +188,7 @@ def patch_anki(
         old_maybe_check_for_addon_updates
     )
     errors.ErrorHandler = old_errorHandler  # type: ignore[misc]
+
+
+def set_qt_message_handler_installer(message_handler_installer: Callable):
+    aqt.qInstallMessageHandler = message_handler_installer  # type: ignore[assignment]

--- a/pytest_anki/_qt.py
+++ b/pytest_anki/_qt.py
@@ -29,7 +29,7 @@
 # Any modifications to this file must keep this entire header intact.
 
 
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 
 from PyQt5.QtCore import QMessageLogContext, QObject, QRunnable, QtMsgType, pyqtSignal
 

--- a/pytest_anki/_qt.py
+++ b/pytest_anki/_qt.py
@@ -47,18 +47,19 @@ class QtMessageMatcher(QObject):
             self.match_found.emit()
 
 
-class SignallingWorker(QObject, QRunnable):
-
+class Signals(QObject):
     finished = pyqtSignal()
 
+
+class SignallingWorker(QRunnable):
     def __init__(
         self,
         task: Callable,
         task_args: Optional[Tuple[Any, ...]] = None,
         task_kwargs: Optional[Dict[str, Any]] = None,
-        parent: Optional[QObject] = None,
     ):
-        super().__init__(parent=parent)
+        super().__init__()
+        self.signals = Signals()
         self._task = task
         self._task_args = task_args or tuple()
         self._task_kwargs = task_kwargs or {}
@@ -71,7 +72,7 @@ class SignallingWorker(QObject, QRunnable):
         except Exception as error:
             self._error = error
         finally:
-            self.finished.emit()
+            self.signals.finished.emit()
 
     @property
     def result(self) -> Optional[Any]:

--- a/pytest_anki/_qt.py
+++ b/pytest_anki/_qt.py
@@ -1,0 +1,45 @@
+# pytest-anki
+#
+# Copyright (C)  2019-2021 Aristotelis P. <https://glutanimate.com/>
+#                and contributors (see CONTRIBUTORS file)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version, with the additions
+# listed at the end of the license file that accompanied this program.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# NOTE: This program is subject to certain additional terms pursuant to
+# Section 7 of the GNU Affero General Public License.  You should have
+# received a copy of these additional terms immediately following the
+# terms and conditions of the GNU Affero General Public License that
+# accompanied this program.
+#
+# If not, please request a copy through one of the means of contact
+# listed here: <https://glutanimate.com/contact/>.
+#
+# Any modifications to this file must keep this entire header intact.
+
+
+from PyQt5.QtCore import QMessageLogContext, QObject, QtMsgType, pyqtSignal
+
+
+class QtMessageMatcher(QObject):
+
+    match_found = pyqtSignal()
+
+    def __init__(self, matched_phrase: str):
+        super().__init__()
+        self._matched_phrase = matched_phrase
+
+    def __call__(self, type: QtMsgType, context: QMessageLogContext, msg: str):
+        if self._matched_phrase in msg:
+            self.match_found.emit()

--- a/pytest_anki/_session.py
+++ b/pytest_anki/_session.py
@@ -39,7 +39,7 @@ from PyQt5.QtWebEngineWidgets import QWebEngineProfile
 from selenium import webdriver
 
 from ._addons import ConfigPaths, create_addon_config
-from ._anki import AnkiStateUpdate, AnkiWebViews, get_collection, update_anki_state
+from ._anki import AnkiStateUpdate, AnkiWebViewType, get_collection, update_anki_state
 from ._errors import AnkiSessionError
 from ._qt import SignallingWorker
 from ._types import PathLike
@@ -317,7 +317,7 @@ class AnkiSession:
     def run_with_chrome_driver(
         self,
         test_function: Callable[[webdriver.Chrome], Optional[bool]],
-        target_web_view: Optional[Union[AnkiWebViews, str]] = None,
+        target_web_view: Optional[Union[AnkiWebViewType, str]] = None,
     ):
         """[summary]
 
@@ -326,8 +326,8 @@ class AnkiSession:
             target_web_view: Web view as identified by its title. Defaults to None.
         """
         web_view_title: Optional[str]
-        
-        if isinstance(target_web_view, AnkiWebViews):
+
+        if isinstance(target_web_view, AnkiWebViewType):
             web_view_title = target_web_view.value
         else:
             web_view_title = target_web_view

--- a/pytest_anki/_session.py
+++ b/pytest_anki/_session.py
@@ -325,6 +325,9 @@ class AnkiSession:
             test_function (Callable[[webdriver.Chrome], Optional[bool]]): [description]
             target_web_view: Web view as identified by its title. Defaults to None.
         """
+        if self._web_debugging_port is None:
+            raise AnkiSessionError("Web debugging interface is not active")
+
         web_view_title: Optional[str]
 
         if isinstance(target_web_view, AnkiWebViewType):

--- a/pytest_anki/_session.py
+++ b/pytest_anki/_session.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
     from aqt import AnkiApp
     from aqt.main import AnkiQt
     from pytestqt.qtbot import QtBot
-    from selenium.webdriver import Chrome
+    from selenium import webdriver
 
 
 class AnkiSession:
@@ -272,7 +272,7 @@ class AnkiSession:
 
     # Web debugging ####
 
-    def run_in_background(self, task: Callable, *task_args: Any, **task_kwargs: Any):
+    def run_in_thread(self, task: Callable, *task_args: Any, **task_kwargs: Any):
         thread_pool = QThreadPool.globalInstance()
         worker = SignallingWorker(
             task=task, task_args=task_args, task_kwargs=task_kwargs
@@ -303,7 +303,9 @@ class AnkiSession:
         self.mw.app.setApplicationName(old_application_name)
         self.mw.app.setApplicationVersion(old_application_version)
 
-    def run_webdriver_test(self, test_function: Callable[["Chrome"], Optional[bool]]):
+    def run_with_chrome_driver(
+        self, test_function: Callable[["webdriver.Chrome"], Optional[bool]]
+    ):
         def test_wrapper() -> Optional[bool]:
             options = ChromeOptions()
             options.add_experimental_option(
@@ -313,4 +315,4 @@ class AnkiSession:
             return test_function(driver)
 
         with self._allow_selenium_to_detect_anki():
-            return self.run_in_background(test_wrapper)
+            return self.run_in_thread(test_wrapper)

--- a/pytest_anki/_session.py
+++ b/pytest_anki/_session.py
@@ -31,7 +31,17 @@
 import re
 from contextlib import contextmanager
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 from anki.importing.apkg import AnkiPackageImporter
 from PyQt5.QtCore import QThreadPool
@@ -271,7 +281,12 @@ class AnkiSession:
 
     # Web debugging ####
 
-    def run_in_thread(self, task: Callable, *task_args: Any, **task_kwargs: Any):
+    def run_in_thread(
+        self,
+        task: Callable,
+        task_args: Optional[Tuple[Any, ...]] = None,
+        task_kwargs: Optional[Dict[str, Any]] = None,
+    ):
         thread_pool = QThreadPool.globalInstance()
         worker = SignallingWorker(
             task=task, task_args=task_args, task_kwargs=task_kwargs

--- a/pytest_anki/_session.py
+++ b/pytest_anki/_session.py
@@ -275,10 +275,10 @@ class AnkiSession:
     def run_in_background(self, task: Callable, *task_args: Any, **task_kwargs: Any):
         thread_pool = QThreadPool.globalInstance()
         worker = SignallingWorker(
-            task=task, parent=self.mw, task_args=task_args, task_kwargs=task_kwargs
+            task=task, task_args=task_args, task_kwargs=task_kwargs
         )
 
-        with self._qtbot.wait_signal(worker.finished):
+        with self._qtbot.wait_signal(worker.signals.finished):
             thread_pool.start(worker)
 
         if exception := worker.error:

--- a/pytest_anki/_util.py
+++ b/pytest_anki/_util.py
@@ -29,9 +29,11 @@
 # Any modifications to this file must keep this entire header intact.
 
 import json
+import socket
+from contextlib import closing
 from functools import reduce
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, List, Union
 
 
 def create_json(path: Union[str, Path], data: dict) -> str:
@@ -71,3 +73,11 @@ def get_nested_attribute(obj: Any, attr: str, *args) -> Any:
         return getattr(obj, attr, *args)
 
     return reduce(_getattr, [obj] + attr.split("."))
+
+
+def find_free_port():
+    # https://stackoverflow.com/a/45690594
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(('', 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]

--- a/pytest_anki/_util.py
+++ b/pytest_anki/_util.py
@@ -78,6 +78,6 @@ def get_nested_attribute(obj: Any, attr: str, *args) -> Any:
 def find_free_port():
     # https://stackoverflow.com/a/45690594
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-        s.bind(('', 0))
+        s.bind(("", 0))
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         return s.getsockname()[1]

--- a/pytest_anki/_util.py
+++ b/pytest_anki/_util.py
@@ -33,7 +33,7 @@ import socket
 from contextlib import closing
 from functools import reduce
 from pathlib import Path
-from typing import Any, List, Union
+from typing import Any, Union
 
 
 def create_json(path: Union[str, Path], data: dict) -> str:

--- a/pytest_anki/plugin.py
+++ b/pytest_anki/plugin.py
@@ -64,21 +64,6 @@ def anki_session(request: "FixtureRequest") -> Iterator[AnkiSession]:
         load_profile {bool} -- Whether to preload Anki user profile (with collection)
             (default: {False})
 
-        packed_addons {Optional[List[PathLike]]}: List of paths to .ankiaddon-packaged
-            add-ons that should be installed ahead of starting Anki
-
-        unpacked_addons {Optional[List[Tuple[str, PathLike]]]}:
-            List of unpacked add-ons that should be installed ahead of starting Anki.
-            Add-ons need to be specified as tuple of the add-on package name under which
-            to install the add-on, and the path to the source folder (the package
-            folder containing the add-on __init__.py)
-
-        addon_configs {Optional[List[Tuple[str, Dict[str, Any]]]]}:
-            List of add-on package names and config values to set the user configuration
-            for the specified add-on to. Useful for simulating specific config set-ups.
-            Each list member needs to be specified as a tuple of add-on package name
-            and dictionary of user configuration values to set.
-
         preset_anki_state {Optional[pytest_anki.AnkiStateUpdate]}:
             Allows pre-configuring Anki object state, as described by a PresetAnkiState
             dataclass. This includes the three main configuration storages used by
@@ -96,6 +81,22 @@ def anki_session(request: "FixtureRequest") -> Iterator[AnkiSession]:
             Please note that, in the case of colconf_storage and profile_storage, the
             caller is responsible for either passing 'load_profile=True', or manually
             loading the profile at a later stage.
+
+        packed_addons {Optional[List[PathLike]]}: List of paths to .ankiaddon-packaged
+            add-ons that should be installed ahead of starting Anki
+
+        unpacked_addons {Optional[List[Tuple[str, PathLike]]]}:
+            List of unpacked add-ons that should be installed ahead of starting Anki.
+            Add-ons need to be specified as tuple of the add-on package name under which
+            to install the add-on, and the path to the source folder (the package
+            folder containing the add-on __init__.py)
+
+        addon_configs {Optional[List[Tuple[str, Dict[str, Any]]]]}:
+            List of add-on package names and config values to set the user configuration
+            for the specified add-on to. Useful for simulating specific config set-ups.
+            Each list member needs to be specified as a tuple of add-on package name
+            and dictionary of user configuration values to set.
+
     """
 
     indirect_parameters: Optional[Dict[str, Any]] = getattr(request, "param", None)

--- a/pytest_anki/plugin.py
+++ b/pytest_anki/plugin.py
@@ -97,6 +97,10 @@ def anki_session(request: "FixtureRequest") -> Iterator[AnkiSession]:
             Each list member needs to be specified as a tuple of add-on package name
             and dictionary of user configuration values to set.
 
+        web_debugging_port {Optional[int]}:
+            If specified, launches Anki with QTWEBENGINE_REMOTE_DEBUGGING set, allowing
+            you to remotely debug Qt web engine views.
+
     """
 
     indirect_parameters: Optional[Dict[str, Any]] = getattr(request, "param", None)

--- a/pytest_anki/plugin.py
+++ b/pytest_anki/plugin.py
@@ -34,13 +34,14 @@ import pytest
 
 if TYPE_CHECKING:
     from pytest import FixtureRequest
+    from pytestqt.qtbot import QtBot
 
 from ._launch import anki_running
 from ._session import AnkiSession
 
 
 @pytest.fixture
-def anki_session(request: "FixtureRequest") -> Iterator[AnkiSession]:
+def anki_session(request: "FixtureRequest", qtbot: "QtBot") -> Iterator[AnkiSession]:
     """Fixture that instantiates Anki, yielding an AnkiSession object
 
     All keyword arguments below may be passed to the fixture by using indirect
@@ -105,7 +106,7 @@ def anki_session(request: "FixtureRequest") -> Iterator[AnkiSession]:
 
     indirect_parameters: Optional[Dict[str, Any]] = getattr(request, "param", None)
 
-    with anki_running() if not indirect_parameters else anki_running(
-        **indirect_parameters
+    with anki_running(qtbot=qtbot) if not indirect_parameters else anki_running(
+        qtbot=qtbot, **indirect_parameters
     ) as session:
         yield session

--- a/tests/test_web_debugging.py
+++ b/tests/test_web_debugging.py
@@ -81,5 +81,8 @@ def test_web_driver_can_interact_with_anki(anki_session: AnkiSession):
         anki_session.run_with_chrome_driver(
             switch_to_deck_view, AnkiWebViewType.main_webview
         )
-        anki_session.qtbot.wait(100)
-        assert anki_session.mw.state == "overview"
+
+        def mw_state_switched():
+            assert anki_session.mw.state == "overview"
+
+        anki_session.qtbot.wait_until(mw_state_switched)

--- a/tests/test_web_debugging.py
+++ b/tests/test_web_debugging.py
@@ -1,0 +1,83 @@
+# pytest-anki
+#
+# Copyright (C)  2019-2021 Aristotelis P. <https://glutanimate.com/>
+#                and contributors (see CONTRIBUTORS file)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version, with the additions
+# listed at the end of the license file that accompanied this program.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# NOTE: This program is subject to certain additional terms pursuant to
+# Section 7 of the GNU Affero General Public License.  You should have
+# received a copy of these additional terms immediately following the
+# terms and conditions of the GNU Affero General Public License that
+# accompanied this program.
+#
+# If not, please request a copy through one of the means of contact
+# listed here: <https://glutanimate.com/contact/>.
+#
+# Any modifications to this file must keep this entire header intact.
+
+from selenium import webdriver
+import requests
+
+from pytest_anki import AnkiSession, AnkiWebViewType
+
+from unittest.mock import Mock
+
+
+def test_run_in_thread(anki_session: AnkiSession):
+    mock_task = Mock()
+    args = tuple((1, 2, 3))
+    kwargs = {"foo": 1, "bar": 2, "zing": 3}
+    anki_session.run_in_thread(task=mock_task, task_args=args, task_kwargs=kwargs)
+    mock_task.assert_called_once_with(*args, **kwargs)
+
+
+def test_web_debugging_available_on_launch(anki_session: AnkiSession):
+    port = anki_session.web_debugging_port
+
+    def assert_web_debugging_interface_up():
+        result = requests.get(f"http://127.0.0.1:{port}/")
+        assert result.status_code == 200
+        assert "Inspectable pages" in result.text
+
+    anki_session.run_in_thread(assert_web_debugging_interface_up)
+
+
+def test_web_driver_can_connect(anki_session: AnkiSession):
+    def assert_web_driver_connected(driver: webdriver.Chrome):
+        assert driver.window_handles
+
+    anki_session.run_with_chrome_driver(assert_web_driver_connected)
+
+
+def test_web_driver_can_select_web_view(anki_session: AnkiSession):
+    def assert_web_driver_connected_to_main_web_view(driver: webdriver.Chrome):
+        assert driver.title == AnkiWebViewType.main_webview.value
+
+    with anki_session.profile_loaded():
+        anki_session.run_with_chrome_driver(
+            assert_web_driver_connected_to_main_web_view, AnkiWebViewType.main_webview
+        )
+
+def test_web_driver_can_interact_with_anki(anki_session: AnkiSession):
+    def switch_to_deck_view(driver: webdriver.Chrome):
+        driver.find_element_by_xpath("//*[text()='Default']").click()
+
+    with anki_session.profile_loaded():
+        assert anki_session.mw.state == "deckBrowser"
+        anki_session.run_with_chrome_driver(
+            switch_to_deck_view, AnkiWebViewType.main_webview
+        )
+        assert anki_session.mw.state == "overview"

--- a/tests/test_web_debugging.py
+++ b/tests/test_web_debugging.py
@@ -28,12 +28,12 @@
 #
 # Any modifications to this file must keep this entire header intact.
 
-from selenium import webdriver
+from unittest.mock import Mock
+
 import requests
+from selenium import webdriver
 
 from pytest_anki import AnkiSession, AnkiWebViewType
-
-from unittest.mock import Mock
 
 
 def test_run_in_thread(anki_session: AnkiSession):
@@ -70,6 +70,7 @@ def test_web_driver_can_select_web_view(anki_session: AnkiSession):
         anki_session.run_with_chrome_driver(
             assert_web_driver_connected_to_main_web_view, AnkiWebViewType.main_webview
         )
+
 
 def test_web_driver_can_interact_with_anki(anki_session: AnkiSession):
     def switch_to_deck_view(driver: webdriver.Chrome):

--- a/tests/test_web_debugging.py
+++ b/tests/test_web_debugging.py
@@ -81,4 +81,5 @@ def test_web_driver_can_interact_with_anki(anki_session: AnkiSession):
         anki_session.run_with_chrome_driver(
             switch_to_deck_view, AnkiWebViewType.main_webview
         )
+        anki_session.qtbot.wait(100)
         assert anki_session.mw.state == "overview"


### PR DESCRIPTION
Adds the ability to launch Anki with Qt WebEngine remote debugging enabled and extends the `AnkiSession` API with a series of helper methods to facilitate testing web views.

----

_Note: This patch was written under commission for AMBOSS MD Inc. Its rights of use and exploitation lie with AMBOSS MD Inc. It is submitted as a contribution to pytest-anki under pytest-anki's license terms (see LICENSE file)._