### PR TITLE
Add option to skip add-on loading

### DIFF
--- a/pytest_anki/_launch.py
+++ b/pytest_anki/_launch.py
@@ -157,7 +157,7 @@ def anki_running(
         web_debugging_port {Optional[int]}:
             If specified, launches Anki with QTWEBENGINE_REMOTE_DEBUGGING set, allowing
             you to remotely debug Qt web engine views.
-        
+
         skip_loading_addons {bool}:
             If set to True, will skip loading packed and unpacked add-ons, giving the
             caller full control over the add-on import time.
@@ -183,7 +183,7 @@ def anki_running(
             unpacked_addons=unpacked_addons,
             addon_configs=addon_configs,
             preset_anki_state=preset_anki_state,
-            skip_loading_addons=skip_loading_addons
+            skip_loading_addons=skip_loading_addons,
         )
 
         # Apply preset Anki profile and collection.conf storage on profile load

--- a/pytest_anki/_launch.py
+++ b/pytest_anki/_launch.py
@@ -104,6 +104,7 @@ def anki_running(
     unpacked_addons: Optional[List[Tuple[str, PathLike]]] = None,
     addon_configs: Optional[List[Tuple[str, Dict[str, Any]]]] = None,
     enable_web_debugging: bool = True,
+    skip_loading_addons: bool = False,
 ) -> Iterator[AnkiSession]:
     """Context manager that safely launches an Anki session, cleaning up after itself
 
@@ -156,6 +157,10 @@ def anki_running(
         web_debugging_port {Optional[int]}:
             If specified, launches Anki with QTWEBENGINE_REMOTE_DEBUGGING set, allowing
             you to remotely debug Qt web engine views.
+        
+        skip_loading_addons {bool}:
+            If set to True, will skip loading packed and unpacked add-ons, giving the
+            caller full control over the add-on import time.
 
     Returns:
         Iterator[AnkiSession] -- [description]
@@ -178,6 +183,7 @@ def anki_running(
             unpacked_addons=unpacked_addons,
             addon_configs=addon_configs,
             preset_anki_state=preset_anki_state,
+            skip_loading_addons=skip_loading_addons
         )
 
         # Apply preset Anki profile and collection.conf storage on profile load

--- a/pytest_anki/_patch.py
+++ b/pytest_anki/_patch.py
@@ -65,7 +65,7 @@ def post_ui_setup_callback_factory(
     unpacked_addons: Optional[List[Tuple[str, PathLike]]] = None,
     addon_configs: Optional[List[Tuple[str, Dict[str, Any]]]] = None,
     preset_anki_state: Optional[AnkiStateUpdate] = None,
-    skip_loading_addons: bool = False
+    skip_loading_addons: bool = False,
 ):
     def post_ui_setup_callback(main_window: AnkiQt):
         """Initialize add-on manager, install add-ons, load add-ons"""

--- a/pytest_anki/_patch.py
+++ b/pytest_anki/_patch.py
@@ -65,6 +65,7 @@ def post_ui_setup_callback_factory(
     unpacked_addons: Optional[List[Tuple[str, PathLike]]] = None,
     addon_configs: Optional[List[Tuple[str, Dict[str, Any]]]] = None,
     preset_anki_state: Optional[AnkiStateUpdate] = None,
+    skip_loading_addons: bool = False
 ):
     def post_ui_setup_callback(main_window: AnkiQt):
         """Initialize add-on manager, install add-ons, load add-ons"""
@@ -97,7 +98,8 @@ def post_ui_setup_callback_factory(
                 main_window=main_window, anki_state_update=preset_anki_state
             )
 
-        main_window.addonManager.loadAddons()
+        if not skip_loading_addons:
+            main_window.addonManager.loadAddons()
 
     return post_ui_setup_callback
 

--- a/pytest_anki/plugin.py
+++ b/pytest_anki/plugin.py
@@ -120,6 +120,9 @@ def anki_session(request: "FixtureRequest", qtbot: "QtBot") -> Iterator[AnkiSess
             If specified, launches Anki with QTWEBENGINE_REMOTE_DEBUGGING set, allowing
             you to remotely debug Qt web engine views.
 
+        skip_loading_addons {bool}:
+            If set to True, will skip loading packed and unpacked add-ons, giving the
+            caller full control over the add-on import time.
     """
 
     indirect_parameters: Optional[Dict[str, Any]] = getattr(request, "param", None)


### PR DESCRIPTION
Optionally skip loading packed and unpacked add-ons, giving the caller full control over the add-on import time.

----

_Note: This patch was written under commission for AMBOSS MD Inc. Its rights of use and exploitation lie with AMBOSS MD Inc. It is submitted as a contribution to pytest-anki under pytest-anki's license terms (see LICENSE file)._